### PR TITLE
Strip unneeded string in Generic flag during usage invocation

### DIFF
--- a/context.go
+++ b/context.go
@@ -131,7 +131,7 @@ func (c *Context) GlobalIsSet(name string) bool {
 // Returns a slice of flag names used in this context.
 func (c *Context) FlagNames() (names []string) {
 	for _, flag := range c.Command.Flags {
-		name := strings.Split(flag.getName(), ",")[0]
+		name := strings.Split(flag.GetName(), ",")[0]
 		if name == "help" {
 			continue
 		}
@@ -143,7 +143,7 @@ func (c *Context) FlagNames() (names []string) {
 // Returns a slice of global flag names used by the app.
 func (c *Context) GlobalFlagNames() (names []string) {
 	for _, flag := range c.App.Flags {
-		name := strings.Split(flag.getName(), ",")[0]
+		name := strings.Split(flag.GetName(), ",")[0]
 		if name == "help" || name == "version" {
 			continue
 		}
@@ -311,7 +311,7 @@ func normalizeFlags(flags []Flag, set *flag.FlagSet) error {
 		visited[f.Name] = true
 	})
 	for _, f := range flags {
-		parts := strings.Split(f.getName(), ",")
+		parts := strings.Split(f.GetName(), ",")
 		if len(parts) == 1 {
 			continue
 		}

--- a/flag.go
+++ b/flag.go
@@ -68,7 +68,7 @@ type GenericFlag struct {
 }
 
 func (f GenericFlag) String() string {
-	return withEnvHint(f.EnvVar, fmt.Sprintf("%s%s %v\t`%v` %s", prefixFor(f.Name), f.Name, f.Value, "-"+f.Name+" option -"+f.Name+" option", f.Usage))
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s%s %v\t%s", prefixFor(f.Name), f.Name, f.Value, f.Usage))
 }
 
 func (f GenericFlag) Apply(set *flag.FlagSet) {

--- a/flag.go
+++ b/flag.go
@@ -33,7 +33,7 @@ type Flag interface {
 	fmt.Stringer
 	// Apply Flag settings to the given flag set
 	Apply(*flag.FlagSet)
-	getName() string
+	GetName() string
 }
 
 func flagSet(name string, flags []Flag) *flag.FlagSet {
@@ -88,7 +88,7 @@ func (f GenericFlag) Apply(set *flag.FlagSet) {
 	})
 }
 
-func (f GenericFlag) getName() string {
+func (f GenericFlag) GetName() string {
 	return f.Name
 }
 
@@ -141,7 +141,7 @@ func (f StringSliceFlag) Apply(set *flag.FlagSet) {
 	})
 }
 
-func (f StringSliceFlag) getName() string {
+func (f StringSliceFlag) GetName() string {
 	return f.Name
 }
 
@@ -203,7 +203,7 @@ func (f IntSliceFlag) Apply(set *flag.FlagSet) {
 	})
 }
 
-func (f IntSliceFlag) getName() string {
+func (f IntSliceFlag) GetName() string {
 	return f.Name
 }
 
@@ -237,7 +237,7 @@ func (f BoolFlag) Apply(set *flag.FlagSet) {
 	})
 }
 
-func (f BoolFlag) getName() string {
+func (f BoolFlag) GetName() string {
 	return f.Name
 }
 
@@ -271,7 +271,7 @@ func (f BoolTFlag) Apply(set *flag.FlagSet) {
 	})
 }
 
-func (f BoolTFlag) getName() string {
+func (f BoolTFlag) GetName() string {
 	return f.Name
 }
 
@@ -311,7 +311,7 @@ func (f StringFlag) Apply(set *flag.FlagSet) {
 	})
 }
 
-func (f StringFlag) getName() string {
+func (f StringFlag) GetName() string {
 	return f.Name
 }
 
@@ -345,7 +345,7 @@ func (f IntFlag) Apply(set *flag.FlagSet) {
 	})
 }
 
-func (f IntFlag) getName() string {
+func (f IntFlag) GetName() string {
 	return f.Name
 }
 
@@ -379,7 +379,7 @@ func (f DurationFlag) Apply(set *flag.FlagSet) {
 	})
 }
 
-func (f DurationFlag) getName() string {
+func (f DurationFlag) GetName() string {
 	return f.Name
 }
 
@@ -412,7 +412,7 @@ func (f Float64Flag) Apply(set *flag.FlagSet) {
 	})
 }
 
-func (f Float64Flag) getName() string {
+func (f Float64Flag) GetName() string {
 	return f.Name
 }
 


### PR DESCRIPTION
String() in GenericFlag returns some extra text that makes the usage output of subcommands with custom GenericFlag look a bit ugly.
For example,
``` --topology 'topology'	`-topology option -topology option` Path to the topology file```

The extraneous text in this case is `-topology option -topology option` whereas the expected usage output is,

``` --topology 'topology'   Path to the topology file```