### PR TITLE
Use double quotes in output for defaults

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -73,7 +73,7 @@ type GenericFlag struct {
 // help text to the user (uses the String() method of the generic flag to show
 // the value)
 func (f GenericFlag) String() string {
-	return withEnvHint(f.EnvVar, fmt.Sprintf("%s%s '%v'\t%v", prefixFor(f.Name), f.Name, f.Value, f.Usage))
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s%s \"%v\"\t%v", prefixFor(f.Name), f.Name, f.Value, f.Usage))
 }
 
 // Apply takes the flagset and calls Set on the generic flag with the value
@@ -124,7 +124,7 @@ type StringSliceFlag struct {
 func (f StringSliceFlag) String() string {
 	firstName := strings.Trim(strings.Split(f.Name, ",")[0], " ")
 	pref := prefixFor(firstName)
-	return withEnvHint(f.EnvVar, fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), pref+firstName+" option "+pref+firstName+" option", f.Usage))
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s [%v]\t%v", prefixedNames(f.Name), pref+firstName+" option "+pref+firstName+" option", f.Usage))
 }
 
 func (f StringSliceFlag) Apply(set *flag.FlagSet) {
@@ -183,7 +183,7 @@ type IntSliceFlag struct {
 func (f IntSliceFlag) String() string {
 	firstName := strings.Trim(strings.Split(f.Name, ",")[0], " ")
 	pref := prefixFor(firstName)
-	return withEnvHint(f.EnvVar, fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), pref+firstName+" option "+pref+firstName+" option", f.Usage))
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s [%v]\t%v", prefixedNames(f.Name), pref+firstName+" option "+pref+firstName+" option", f.Usage))
 }
 
 func (f IntSliceFlag) Apply(set *flag.FlagSet) {
@@ -294,7 +294,7 @@ func (f StringFlag) String() string {
 	fmtString = "%s %v\t%v"
 
 	if len(f.Value) > 0 {
-		fmtString = "%s '%v'\t%v"
+		fmtString = "%s \"%v\"\t%v"
 	} else {
 		fmtString = "%s %v\t%v"
 	}
@@ -330,7 +330,7 @@ type IntFlag struct {
 }
 
 func (f IntFlag) String() string {
-	return withEnvHint(f.EnvVar, fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), f.Value, f.Usage))
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s \"%v\"\t%v", prefixedNames(f.Name), f.Value, f.Usage))
 }
 
 func (f IntFlag) Apply(set *flag.FlagSet) {
@@ -364,7 +364,7 @@ type DurationFlag struct {
 }
 
 func (f DurationFlag) String() string {
-	return withEnvHint(f.EnvVar, fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), f.Value, f.Usage))
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s \"%v\"\t%v", prefixedNames(f.Name), f.Value, f.Usage))
 }
 
 func (f DurationFlag) Apply(set *flag.FlagSet) {
@@ -398,7 +398,7 @@ type Float64Flag struct {
 }
 
 func (f Float64Flag) String() string {
-	return withEnvHint(f.EnvVar, fmt.Sprintf("%s '%v'\t%v", prefixedNames(f.Name), f.Value, f.Usage))
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s \"%v\"\t%v", prefixedNames(f.Name), f.Value, f.Usage))
 }
 
 func (f Float64Flag) Apply(set *flag.FlagSet) {

--- a/flag_test.go
+++ b/flag_test.go
@@ -38,7 +38,7 @@ var stringFlagTests = []struct {
 	{"help", "", "--help \t"},
 	{"h", "", "-h \t"},
 	{"h", "", "-h \t"},
-	{"test", "Something", "--test 'Something'\t"},
+	{"test", "Something", "--test \"Something\"\t"},
 }
 
 func TestStringFlagHelpOutput(t *testing.T) {
@@ -75,22 +75,22 @@ var stringSliceFlagTests = []struct {
 		s := &cli.StringSlice{}
 		s.Set("")
 		return s
-	}(), "--help '--help option --help option'\t"},
+	}(), "--help [--help option --help option]\t"},
 	{"h", func() *cli.StringSlice {
 		s := &cli.StringSlice{}
 		s.Set("")
 		return s
-	}(), "-h '-h option -h option'\t"},
+	}(), "-h [-h option -h option]\t"},
 	{"h", func() *cli.StringSlice {
 		s := &cli.StringSlice{}
 		s.Set("")
 		return s
-	}(), "-h '-h option -h option'\t"},
+	}(), "-h [-h option -h option]\t"},
 	{"test", func() *cli.StringSlice {
 		s := &cli.StringSlice{}
 		s.Set("Something")
 		return s
-	}(), "--test '--test option --test option'\t"},
+	}(), "--test [--test option --test option]\t"},
 }
 
 func TestStringSliceFlagHelpOutput(t *testing.T) {
@@ -122,8 +122,8 @@ var intFlagTests = []struct {
 	name     string
 	expected string
 }{
-	{"help", "--help '0'\t"},
-	{"h", "-h '0'\t"},
+	{"help", "--help \"0\"\t"},
+	{"h", "-h \"0\"\t"},
 }
 
 func TestIntFlagHelpOutput(t *testing.T) {
@@ -155,8 +155,8 @@ var durationFlagTests = []struct {
 	name     string
 	expected string
 }{
-	{"help", "--help '0'\t"},
-	{"h", "-h '0'\t"},
+	{"help", "--help \"0\"\t"},
+	{"h", "-h \"0\"\t"},
 }
 
 func TestDurationFlagHelpOutput(t *testing.T) {
@@ -189,14 +189,14 @@ var intSliceFlagTests = []struct {
 	value    *cli.IntSlice
 	expected string
 }{
-	{"help", &cli.IntSlice{}, "--help '--help option --help option'\t"},
-	{"h", &cli.IntSlice{}, "-h '-h option -h option'\t"},
-	{"h", &cli.IntSlice{}, "-h '-h option -h option'\t"},
+	{"help", &cli.IntSlice{}, "--help [--help option --help option]\t"},
+	{"h", &cli.IntSlice{}, "-h [-h option -h option]\t"},
+	{"h", &cli.IntSlice{}, "-h [-h option -h option]\t"},
 	{"test", func() *cli.IntSlice {
 		i := &cli.IntSlice{}
 		i.Set("9")
 		return i
-	}(), "--test '--test option --test option'\t"},
+	}(), "--test [--test option --test option]\t"},
 }
 
 func TestIntSliceFlagHelpOutput(t *testing.T) {
@@ -228,8 +228,8 @@ var float64FlagTests = []struct {
 	name     string
 	expected string
 }{
-	{"help", "--help '0'\t"},
-	{"h", "-h '0'\t"},
+	{"help", "--help \"0\"\t"},
+	{"h", "-h \"0\"\t"},
 }
 
 func TestFloat64FlagHelpOutput(t *testing.T) {
@@ -262,8 +262,8 @@ var genericFlagTests = []struct {
 	value    cli.Generic
 	expected string
 }{
-	{"test", &Parser{"abc", "def"}, "--test 'abc,def'\ttest flag"},
-	{"t", &Parser{"abc", "def"}, "-t 'abc,def'\ttest flag"},
+	{"test", &Parser{"abc", "def"}, "--test \"abc,def\"\ttest flag"},
+	{"t", &Parser{"abc", "def"}, "-t \"abc,def\"\ttest flag"},
 }
 
 func TestGenericFlagHelpOutput(t *testing.T) {


### PR DESCRIPTION
Windows doesn't recognize 's for wrapping values. "s should work on all
systems.

Fixes #136 