### PR TITLE
strconv.ParseInt should be used instead of strconv.ParseUint when readin...

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -338,7 +338,7 @@ func (f IntFlag) Apply(set *flag.FlagSet) {
 		for _, envVar := range strings.Split(f.EnvVar, ",") {
 			envVar = strings.TrimSpace(envVar)
 			if envVal := os.Getenv(envVar); envVal != "" {
-				envValInt, err := strconv.ParseUint(envVal, 10, 64)
+				envValInt, err := strconv.ParseInt(envVal, 10, 64)
 				if err == nil {
 					f.Value = int(envValInt)
 					break


### PR DESCRIPTION
It looks like when IntFlag is obtained from reading and Environment Variable, instead of directly from command line, `ParseUint` is being used, yet this should be a Signed Int flag, so negative values will likely result in 0 being read from the Environment, since the `ParseUint` will not work correctly with a `0<` number. I believe we really want `ParseInt` here instead.