### PR TITLE
Use 0 as the base when parsing ints

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -338,7 +338,7 @@ func (f IntFlag) Apply(set *flag.FlagSet) {
 		for _, envVar := range strings.Split(f.EnvVar, ",") {
 			envVar = strings.TrimSpace(envVar)
 			if envVal := os.Getenv(envVar); envVal != "" {
-				envValInt, err := strconv.ParseInt(envVal, 10, 64)
+				envValInt, err := strconv.ParseInt(envVal, 0, 64)
 				if err == nil {
 					f.Value = int(envValInt)
 					break


### PR DESCRIPTION
To be consistent with what the stdlib flag package does (allows for users to use numbers in other bases as flags).

http://golang.org/src/flag/flag.go?s=14139:14203#L479