### PR TITLE
Use parsed context when running command as subcommnd

### DIFF
--- a/app.go
+++ b/app.go
@@ -242,11 +242,7 @@ func (a *App) RunAsSubcommand(ctx *Context) error {
 	}
 
 	// Run default Action
-	if len(a.Commands) > 0 {
-		a.Action(context)
-	} else {
-		a.Action(ctx)
-	}
+	a.Action(context)
 
 	return nil
 }

--- a/app_test.go
+++ b/app_test.go
@@ -193,6 +193,32 @@ func TestApp_CommandWithArgBeforeFlags(t *testing.T) {
 	expect(t, firstArg, "my-arg")
 }
 
+func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
+	var context *cli.Context
+
+	a := cli.NewApp()
+	a.Commands = []cli.Command{
+		{
+			Name: "foo",
+			Action: func(c *cli.Context) {
+				context = c
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "lang",
+					Value: "english",
+					Usage: "language for the greeting",
+				},
+			},
+			Before: func(_ *cli.Context) error { return nil },
+		},
+	}
+	a.Run([]string{"", "foo", "--lang", "spanish", "abcd"})
+
+	expect(t, context.Args().Get(0), "abcd")
+	expect(t, context.String("lang"), "spanish")
+}
+
 func TestApp_CommandWithFlagBeforeTerminator(t *testing.T) {
 	var parsedOption string
 	var args []string


### PR DESCRIPTION
Rather than passing the unparsed context (parent context) in whenever
there are no subcommands.

Fixes #92 