### PR TITLE
Add new func GlobalArgs in context, and new SkipFlagNotDefined in command

### DIFF
--- a/command.go
+++ b/command.go
@@ -29,6 +29,8 @@ type Command struct {
 	Flags []Flag
 	// Treat all flags as normal arguments if true
 	SkipFlagParsing bool
+	// Skip flag provided and not defined if true
+	SkipFlagNotDefined bool
 	// Boolean to hide built-in help command
 	HideHelp bool
 }
@@ -86,10 +88,12 @@ func (c Command) Run(ctx *Context) error {
 	}
 
 	if err != nil {
-		fmt.Fprint(ctx.App.Writer, "Incorrect Usage.\n\n")
-		ShowCommandHelp(ctx, c.Name)
-		fmt.Fprintln(ctx.App.Writer)
-		return err
+		if !c.SkipFlagNotDefined || !strings.Contains(err.Error(), "flag provided but not defined") {
+			fmt.Fprint(ctx.App.Writer, "Incorrect Usage.\n\n")
+			ShowCommandHelp(ctx, c.Name)
+			fmt.Fprintln(ctx.App.Writer)
+			return err
+		}
 	}
 
 	nerr := normalizeFlags(c.Flags, set)

--- a/command_test.go
+++ b/command_test.go
@@ -47,3 +47,24 @@ func TestCommandIgnoreFlags(t *testing.T) {
 
 	expect(t, err, nil)
 }
+
+func TestCommandSkipFlags(t *testing.T) {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	test := []string{"blah", "blah", "-break"}
+	set.Parse(test)
+
+	c := cli.NewContext(app, set, set)
+
+	command := cli.Command{
+		Name:               "test-cmd",
+		ShortName:          "tc",
+		Usage:              "this is for testing",
+		Description:        "testing",
+		Action:             func(_ *cli.Context) {},
+		SkipFlagNotDefined: true,
+	}
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}

--- a/context.go
+++ b/context.go
@@ -160,6 +160,12 @@ func (c *Context) Args() Args {
 	return args
 }
 
+// Returns the command line arguments.
+func (c *Context) GlobalArgs() Args {
+	args := Args(c.globalSet.Args())
+	return args
+}
+
 // Returns the nth argument, or else a blank string
 func (a Args) Get(n int) string {
 	if len(a) > n {


### PR DESCRIPTION
`SkipFlagNotDefined` is used for when raise flag not defined error,
continue to execute, not print error/help message.