### PR TITLE
Allow commands to be hidden from help and autocomplete

### DIFF
--- a/command.go
+++ b/command.go
@@ -31,6 +31,8 @@ type Command struct {
 	SkipFlagParsing bool
 	// Boolean to hide built-in help command
 	HideHelp bool
+	// Boolean to hide this command from help or completion
+	Hidden bool
 }
 
 // Invokes the command given the context, parses ctx.Args() to generate command-specific flags

--- a/help.go
+++ b/help.go
@@ -19,7 +19,7 @@ AUTHOR:{{if .Author}}
   {{.Email}}{{end}}{{end}}
 
 COMMANDS:
-   {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
+   {{range .Commands}}{{if not .Hidden}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}{{end}}
    {{end}}{{if .Flags}}
 GLOBAL OPTIONS:
    {{range .Flags}}{{.}}
@@ -53,7 +53,7 @@ USAGE:
    {{.Name}} command{{if .Flags}} [command options]{{end}} [arguments...]
 
 COMMANDS:
-   {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
+   {{range .Commands}}{{if not .Hidden}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}{{end}}
    {{end}}{{if .Flags}}
 OPTIONS:
    {{range .Flags}}{{.}}
@@ -103,6 +103,9 @@ func ShowAppHelp(c *Context) {
 // Prints the list of subcommands as the default app completion method
 func DefaultAppComplete(c *Context) {
 	for _, command := range c.App.Commands {
+		if command.Hidden {
+			continue
+		}
 		fmt.Fprintln(c.App.Writer, command.Name)
 		if command.ShortName != "" {
 			fmt.Fprintln(c.App.Writer, command.ShortName)


### PR DESCRIPTION
It would be great if commands can be hidden from the user. This PR does exactly that.