### PR TITLE
Fixing the issue with a command with subcommands not showing help message

### DIFF
--- a/command.go
+++ b/command.go
@@ -119,7 +119,7 @@ func (c Command) Run(ctx *Context) error {
 
 // Returns true if Command.Name or Command.ShortName matches given name
 func (c Command) HasName(name string) bool {
-	return c.Name == name || c.ShortName == name
+	return c.Name == name || (c != "" && c.ShortName == name)
 }
 
 func (c Command) startApp(ctx *Context) error {

--- a/help.go
+++ b/help.go
@@ -112,6 +112,12 @@ func DefaultAppComplete(c *Context) {
 
 // Prints help for the given command
 func ShowCommandHelp(c *Context, command string) {
+	// show the subcommand help for a command with subcommands
+	if command == "" {
+		HelpPrinter(SubcommandHelpTemplate, c.App)
+		return
+	}
+
 	for _, c := range c.App.Commands {
 		if c.HasName(command) {
 			HelpPrinter(CommandHelpTemplate, c)


### PR DESCRIPTION
I think it might close a bunch of issues about it.

It happens if you define a command (let's say `foo`) with subcommands (let's say `bar` and `baz`).
And if you type `mytool foo -h`, only the first subcommand help is shown (so here, `bar`).
I've seen that a new App structure is created based on the first command, and so the following issues:
- the command name is set to "" and HasName was returning true for an empty ShortName, therefore returning the first subcommand all the time (providing your subcommand has no shortname).
- the Show method wasn't aware that command name was just "" and returned the first subcommand.