### PR TITLE
Added an API for number of flags set

### DIFF
--- a/context.go
+++ b/context.go
@@ -106,6 +106,11 @@ func (c *Context) GlobalGeneric(name string) interface{} {
 	return lookupGeneric(name, c.globalSet)
 }
 
+// Returns the number of flags set
+func (c *Context) NumFlags() int {
+	return c.flagSet.NFlag()
+}
+
 // Determines if the flag was actually set
 func (c *Context) IsSet(name string) bool {
 	if c.setFlags == nil {

--- a/context_test.go
+++ b/context_test.go
@@ -97,3 +97,15 @@ func TestContext_GlobalIsSet(t *testing.T) {
 	expect(t, c.GlobalIsSet("myflagGlobalUnset"), false)
 	expect(t, c.GlobalIsSet("bogusGlobal"), false)
 }
+
+func TestContext_NumFlags(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	set.String("otherflag", "hello world", "doc")
+	globalSet := flag.NewFlagSet("test", 0)
+	globalSet.Bool("myflagGlobal", true, "doc")
+	c := cli.NewContext(nil, set, globalSet)
+	set.Parse([]string{"--myflag", "--otherflag=foo"})
+	globalSet.Parse([]string{"--myflagGlobal"})
+	expect(t, c.NumFlags(), 2)
+}


### PR DESCRIPTION
Use case - A global flag and per command flags are not compatible. Want to check if global flag and any command flag are set together. Without this API, the check is very tedious as every per command flag needs to be checked explicitly.