### PR TITLE
Add IsHelp method to Context.

### DIFF
--- a/context.go
+++ b/context.go
@@ -122,6 +122,23 @@ func (c *Context) IsSet(name string) bool {
 	return c.setFlags[name] == true
 }
 
+// Determines if the help command was passed or if the flag was set.
+func (c *Context) IsHelp() bool {
+	if c.IsSet("help") || c.IsSet("h") {
+		return true
+	}
+
+	if c.Command.HideHelp == false {
+		for _, arg := range c.Args() {
+			if arg == "help" || arg == "h" {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // Determines if the global flag was actually set
 func (c *Context) GlobalIsSet(name string) bool {
 	if c.globalSetFlags == nil {

--- a/context_test.go
+++ b/context_test.go
@@ -109,3 +109,52 @@ func TestContext_NumFlags(t *testing.T) {
 	globalSet.Parse([]string{"--myflagGlobal"})
 	expect(t, c.NumFlags(), 2)
 }
+
+func TestContext_IsHelp(t *testing.T) {
+	var helpPassed bool
+
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("help", true, "doc")
+	c := cli.NewContext(nil, set, set)
+	set.Parse([]string{"--help"})
+	expect(t, c.IsHelp(), true)
+
+	set = flag.NewFlagSet("test", 0)
+	set.Bool("h", true, "doc")
+	c = cli.NewContext(nil, set, set)
+	set.Parse([]string{"--h"})
+	expect(t, c.IsHelp(), true)
+
+	set = flag.NewFlagSet("test", 0)
+	set.Bool("someflag", true, "doc")
+	c = cli.NewContext(nil, set, set)
+	set.Parse([]string{"--someflag"})
+	expect(t, c.IsHelp(), false)
+
+	app := cli.NewApp()
+	command := cli.Command{
+		Name: "cmd",
+		Action: func(c *cli.Context) {
+			helpPassed = c.IsHelp()
+		},
+	}
+	app.Commands = []cli.Command{command}
+	app.Run([]string{"", "cmd", "help"})
+	expect(t, helpPassed, true)
+	app.Run([]string{"", "cmd", "argc"})
+	expect(t, helpPassed, false)
+
+	app = cli.NewApp()
+	command = cli.Command{
+		Name: "cmd",
+		HideHelp: true,
+		Action: func(c *cli.Context) {
+			helpPassed = c.IsHelp()
+		},
+	}
+	app.Commands = []cli.Command{command}
+	app.Run([]string{"", "cmd", "help"})
+	expect(t, helpPassed, false)
+	app.Run([]string{"", "cmd", "argc"})
+	expect(t, helpPassed, false)
+}


### PR DESCRIPTION
My use case was calling this to do early returns from Before functions that setup state where some
flags / environment variables are mandatory (e.g. reading keys/token from the environment/files).