### PR TITLE
replace tab before authors with two spaces

### DIFF
--- a/help.go
+++ b/help.go
@@ -15,7 +15,7 @@ VERSION:
    {{.Version}}
 
 AUTHOR(S): 
-	{{range .Authors}}{{ . }} {{end}}
+   {{range .Authors}}{{ . }} {{end}}
 
 COMMANDS:
    {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}


### PR DESCRIPTION
this makes authors consistent with everything else