### PR TITLE
fix panic on broken pipe

### DIFF
--- a/app.go
+++ b/app.go
@@ -90,10 +90,7 @@ func (a *App) Run(arguments []string) (err error) {
 		HelpPrinter = func(templ string, data interface{}) {
 			w := tabwriter.NewWriter(a.Writer, 0, 8, 1, '\t', 0)
 			t := template.Must(template.New("help").Parse(templ))
-			err := t.Execute(w, data)
-			if err != nil {
-				panic(err)
-			}
+			t.Execute(w, data)
 			w.Flush()
 		}
 	}


### PR DESCRIPTION
If the help printer tries writing to a broken pipe (e.g. `myprog --help | exec-that-does-not-exist`), a runtime panic would occur. This patch removes the panic.