### PR TITLE
Add regression test for missing help topics

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1,9 +1,11 @@
 package cli_test
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/codegangsta/cli"
@@ -619,4 +621,59 @@ func TestGlobalFlagsInSubcommands(t *testing.T) {
 	app.Run([]string{"command", "-d", "foo", "bar"})
 
 	expect(t, subcommandRun, true)
+}
+
+func TestApp_CommandWithSubcommandHasHelpTopic(t *testing.T) {
+
+	var subcommandHelpTopics = [][]string{
+		{"command", "foo", "--help"},
+		{"command", "foo", "-h"},
+		{"command", "foo", "help"},
+	}
+
+	for _, flagSet := range subcommandHelpTopics {
+		t.Logf("==> checking with flags %v", flagSet)
+
+		app := cli.NewApp()
+		// capture the output of the app
+		buf := bytes.NewBuffer(nil)
+		app.Writer = buf
+
+		subCmdBar := cli.Command{
+			Name:  "bar",
+			Usage: "does bar things",
+		}
+		subCmdBaz := cli.Command{
+			Name:  "baz",
+			Usage: "does baz things",
+		}
+		cmd := cli.Command{
+			Name:        "foo",
+			Description: "descriptive wall of text about how it does foo things",
+			Subcommands: []cli.Command{subCmdBar, subCmdBaz},
+		}
+
+		app.Commands = []cli.Command{cmd}
+		err := app.Run(flagSet)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		output := buf.String()
+
+		if strings.Contains(output, "No help topic for") {
+			t.Fatalf("expect a help topic, got none: \n%q", output)
+		}
+
+		for _, shouldContain := range []string{
+			cmd.Name, cmd.Description,
+			subCmdBar.Name, subCmdBar.Usage,
+			subCmdBaz.Name, subCmdBaz.Usage,
+		} {
+			if !strings.Contains(output, shouldContain) {
+				t.Fatalf("want help to contain %q, did not: \n%q", shouldContain, output)
+			}
+		}
+	}
 }

--- a/command.go
+++ b/command.go
@@ -158,6 +158,13 @@ func (c Command) startApp(ctx *Context) error {
 	app.Flags = c.Flags
 	app.HideHelp = c.HideHelp
 
+	app.Version = ctx.App.Version
+	app.HideVersion = ctx.App.HideVersion
+	app.Compiled = ctx.App.Compiled
+	app.Author = ctx.App.Author
+	app.Email = ctx.App.Email
+	app.Writer = ctx.App.Writer
+
 	// bash completion
 	app.EnableBashCompletion = ctx.App.EnableBashCompletion
 	if c.BashComplete != nil {


### PR DESCRIPTION
Hi there,

I was working on fixing missing help topics on subcommands when I realized a PR fixing that was merged 9 days ago. Since I wrote a regression test as part of my work, I thought I could provide it to the project so that the issue doesn't appear again.

Also it sets the `Version`/`Author`/etc fields in the child app created by the command.

related to #186 and #163