### PR TITLE
Clean Shutdown

### DIFF
--- a/app.go
+++ b/app.go
@@ -328,7 +328,7 @@ func (a Author) String() string {
 }
 
 func watchForShutdown(f func(*Context), context *Context) {
-	c := make(chan os.Signal, 1)
+	c := make(chan os.Signal, 2)
 	signal.Notify(c)
 	<-c
 	f(context)


### PR DESCRIPTION
- Watch for signals
- Call a Shutdown action when a signal is received

I thought this would be a nice addition. Gives you a chance to call server.Stop() or just os.Exit(0). Putting it in cli means writing less identical code even if it is just a channel and a call to Notify.