### PR TITLE
Add parent name to subcommand name when help is called

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -89,10 +89,10 @@ func ExampleAppHelp() {
 	app.Run(os.Args)
 	// Output:
 	// NAME:
-	//    describeit - use it to see a description
+	//    greet describeit - use it to see a description
 	//
 	// USAGE:
-	//    command describeit [arguments...]
+	//    greet describeit [arguments...]
 	//
 	// DESCRIPTION:
 	//    This is how we describe describeit the function

--- a/help.go
+++ b/help.go
@@ -14,7 +14,7 @@ USAGE:
 VERSION:
    {{.Version}}
 
-AUTHOR(S): 
+AUTHOR(S):
    {{range .Authors}}{{ . }}
    {{end}}
 COMMANDS:
@@ -32,7 +32,7 @@ var CommandHelpTemplate = `NAME:
    {{.Name}} - {{.Usage}}
 
 USAGE:
-   command {{.Name}}{{if .Flags}} [command options]{{end}} [arguments...]{{if .Description}}
+   {{.Name}}{{if .Flags}} [command options]{{end}} [arguments...]{{if .Description}}
 
 DESCRIPTION:
    {{.Description}}{{end}}{{if .Flags}}
@@ -116,9 +116,10 @@ func ShowCommandHelp(c *Context, command string) {
 		return
 	}
 
-	for _, c := range c.App.Commands {
-		if c.HasName(command) {
-			HelpPrinter(CommandHelpTemplate, c)
+	for _, command_ := range c.App.Commands {
+		if command_.HasName(command) {
+			command_.Name = fmt.Sprintf("%s %s", c.App.Name, command_.Name)
+			HelpPrinter(CommandHelpTemplate, command_)
 			return
 		}
 	}


### PR DESCRIPTION
Normally the subcommand's name is updated when startApp is called, but
we have to make a special exception for the help file, since it's a
different sub-command that's getting started.