### PR TITLE
Readd printHelp function back

### DIFF
--- a/app.go
+++ b/app.go
@@ -5,9 +5,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
-	"text/tabwriter"
-	"text/template"
 	"time"
 )
 
@@ -81,26 +78,6 @@ func NewApp() *App {
 func (a *App) Run(arguments []string) (err error) {
 	if a.Author != "" || a.Email != "" {
 		a.Authors = append(a.Authors, Author{Name: a.Author, Email: a.Email})
-	}
-
-	if HelpPrinter == nil {
-		defer func() {
-			HelpPrinter = nil
-		}()
-
-		HelpPrinter = func(templ string, data interface{}) {
-			funcMap := template.FuncMap{
-				"join": strings.Join,
-			}
-
-			w := tabwriter.NewWriter(a.Writer, 0, 8, 1, '\t', 0)
-			t := template.Must(template.New("help").Funcs(funcMap).Parse(templ))
-			err := t.Execute(w, data)
-			if err != nil {
-				panic(err)
-			}
-			w.Flush()
-		}
 	}
 
 	// append help to commands

--- a/app_test.go
+++ b/app_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"testing"
 
@@ -537,7 +538,7 @@ func TestAppHelpPrinter(t *testing.T) {
 	}()
 
 	var wasCalled = false
-	cli.HelpPrinter = func(template string, data interface{}) {
+	cli.HelpPrinter = func(w io.Writer, template string, data interface{}) {
 		wasCalled = true
 	}
 


### PR DESCRIPTION
Was removed in 60e3dcaf

Setting the package level function in `App.Run` makes it difficult to test the help functionality in isolation.

We update signature to take a writer. This is a backwards incompatible
change for those overriding the HelpPrinter, but the hope is that this
feature is largely unused and the usage is easily updated and not doing this makes it difficult to override the help writer in a way that would be consistent with what the rest of the `App` is `Write`ing to.