### PR TITLE
Update string slice usage

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -124,7 +124,7 @@ type StringSliceFlag struct {
 func (f StringSliceFlag) String() string {
 	firstName := strings.Trim(strings.Split(f.Name, ",")[0], " ")
 	pref := prefixFor(firstName)
-	return withEnvHint(f.EnvVar, fmt.Sprintf("%s [%v]\t%v", prefixedNames(f.Name), pref+firstName+" option "+pref+firstName+" option", f.Usage))
+	return withEnvHint(f.EnvVar, fmt.Sprintf("%s [%v]\t%v", prefixedNames(f.Name), pref+firstName+" ...", f.Usage))
 }
 
 func (f StringSliceFlag) Apply(set *flag.FlagSet) {

--- a/flag_test.go
+++ b/flag_test.go
@@ -75,22 +75,22 @@ var stringSliceFlagTests = []struct {
 		s := &cli.StringSlice{}
 		s.Set("")
 		return s
-	}(), "--help [--help option --help option]\t"},
+	}(), "--help [--help ...]\t"},
 	{"h", func() *cli.StringSlice {
 		s := &cli.StringSlice{}
 		s.Set("")
 		return s
-	}(), "-h [-h option -h option]\t"},
+	}(), "-h [-h ...]\t"},
 	{"h", func() *cli.StringSlice {
 		s := &cli.StringSlice{}
 		s.Set("")
 		return s
-	}(), "-h [-h option -h option]\t"},
+	}(), "-h [-h ...]\t"},
 	{"test", func() *cli.StringSlice {
 		s := &cli.StringSlice{}
 		s.Set("Something")
 		return s
-	}(), "--test [--test option --test option]\t"},
+	}(), "--test [--test ...]\t"},
 }
 
 func TestStringSliceFlagHelpOutput(t *testing.T) {


### PR DESCRIPTION
Feel free to close I guess it's a change some ppl won't like :)

I like how the `StringSliceFlag` usage is constructed.

Let's take `--help [--help option --help option]`

* It's very wide
* The first --help don't have option but the 2 others have
* Why limit to 2 ?

It doesn't feel very intuitive for me.

I propose something simpler: `--help [--help ...]`