### PR TITLE
Fix panic if Valus in Int/StringSliceFlasg is missing

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -342,6 +342,38 @@ func TestApp_ParseSliceFlags(t *testing.T) {
 	}
 }
 
+func TestApp_ParseSliceFlagsWithMissingValue(t *testing.T) {
+	var parsedIntSlice []int
+	var parsedStringSlice []string
+
+	app := cli.NewApp()
+	command := cli.Command{
+		Name: "cmd",
+		Flags: []cli.Flag{
+			cli.IntSliceFlag{Name: "a", Usage: "set numbers"},
+			cli.StringSliceFlag{Name: "str", Usage: "set strings"},
+		},
+		Action: func(c *cli.Context) {
+			parsedIntSlice = c.IntSlice("a")
+			parsedStringSlice = c.StringSlice("str")
+		},
+	}
+	app.Commands = []cli.Command{command}
+
+	app.Run([]string{"", "cmd", "my-arg", "-a", "2", "-str", "A"})
+
+	var expectedIntSlice = []int{2}
+	var expectedStringSlice = []string{"A"}
+
+	if parsedIntSlice[0] != expectedIntSlice[0] {
+		t.Errorf("%v does not match %v", parsedIntSlice[0], expectedIntSlice[0])
+	}
+
+	if parsedStringSlice[0] != expectedStringSlice[0] {
+		t.Errorf("%v does not match %v", parsedIntSlice[0], expectedIntSlice[0])
+	}
+}
+
 func TestApp_DefaultStdout(t *testing.T) {
 	app := cli.NewApp()
 

--- a/flag.go
+++ b/flag.go
@@ -144,6 +144,9 @@ func (f StringSliceFlag) Apply(set *flag.FlagSet) {
 	}
 
 	eachName(f.Name, func(name string) {
+		if f.Value == nil {
+			f.Value = &StringSlice{}
+		}
 		set.Var(f.Value, name, f.Usage)
 	})
 }
@@ -206,6 +209,9 @@ func (f IntSliceFlag) Apply(set *flag.FlagSet) {
 	}
 
 	eachName(f.Name, func(name string) {
+		if f.Value == nil {
+			f.Value = &IntSlice{}
+		}
 		set.Var(f.Value, name, f.Usage)
 	})
 }


### PR DESCRIPTION
Hi!
I found that we get panic if parameter Value in ```IntSliceFlag``` or in ```StringSliceFlag``` was missed. For example:
```go
cli.StringSliceFlag {
   	Name: "Files",
   	Usage: "Get all of your files",
  },
```
And output:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x1 pc=0x80823ac]

goroutine 1 [running]:
github.com/codegangsta/cli.(*StringSlice).String(0x0, 0x0, 0x0)
	/home/haunted/gopath/src/github.com/codegangsta/cli/flag.go:110 +0xdc
flag.(*FlagSet).Var(0x1843a090, 0xb77c6b60, 0x0, 0x8155978, 0x5, 0x8167788, 0x15)
```
This behavior is identical as in #179, however, this issue was closed, but problem wasn't solved. I just fixed it and provide additional test.