### PR TITLE
Allow context value to be set after parse

### DIFF
--- a/context.go
+++ b/context.go
@@ -132,6 +132,11 @@ func (c *Context) NumFlags() int {
 	return c.flagSet.NFlag()
 }
 
+// Set sets a context flag to a value.
+func (c *Context) Set(name, value string) error {
+	return c.flagSet.Set(name, value)
+}
+
 // Determines if the flag was actually set
 func (c *Context) IsSet(name string) bool {
 	if c.setFlags == nil {

--- a/context_test.go
+++ b/context_test.go
@@ -113,3 +113,12 @@ func TestContext_NumFlags(t *testing.T) {
 	globalSet.Parse([]string{"--myflagGlobal"})
 	expect(t, c.NumFlags(), 2)
 }
+
+func TestContext_Set(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Int("int", 5, "an int")
+	c := cli.NewContext(nil, set, nil)
+
+	c.Set("int", "1")
+	expect(t, c.Int("int"), 1)
+}


### PR DESCRIPTION
This change allows a context value to be set after parsing. The use case is updating default settings in a Before func. 

An example usage:

```go 
f, err := os.Open(configPath)
if err == nil {
  config, err := docli.NewConfig(f)
  if err != nil {
    panic(err)
  }

  // set token and children contexts will never know where it came from
  c.Set("token", config.APIKey)
}
```