### PR TITLE
Add the ability to add a copyright

### DIFF
--- a/app.go
+++ b/app.go
@@ -43,6 +43,8 @@ type App struct {
 	Compiled time.Time
 	// List of all authors who contributed
 	Authors []Author
+	// Copyright of the binary if any
+	Copyright string
 	// Name of Author (Note: Use App.Authors, this is deprecated)
 	Author string
 	// Email of Author (Note: Use App.Authors, this is deprecated)

--- a/help.go
+++ b/help.go
@@ -28,7 +28,10 @@ COMMANDS:
    {{end}}{{if .Flags}}
 GLOBAL OPTIONS:
    {{range .Flags}}{{.}}
-   {{end}}{{end}}
+   {{end}}{{end}}{{if .Copyright }}
+COPYRIGHT:
+   {{.Copyright}}{{end}}
+
 `
 
 // The text template for the command help topic.

--- a/help.go
+++ b/help.go
@@ -31,7 +31,6 @@ GLOBAL OPTIONS:
    {{end}}{{end}}{{if .Copyright }}
 COPYRIGHT:
    {{.Copyright}}{{end}}
-
 `
 
 // The text template for the command help topic.


### PR DESCRIPTION
References #237 . Some license types such as BSD require the ability for binaries to reproduce their copyright. 

Adds:
```
app.Copyright = "(c) 2015"
```

Which yields:

```
COPYRIGHT:
   (c) 2015
```

Following the `GLOBAL OPTIONS` section.