### PR TITLE
Add func to get context parent

### DIFF
--- a/context.go
+++ b/context.go
@@ -180,6 +180,11 @@ func (c *Context) GlobalFlagNames() (names []string) {
 	return
 }
 
+// Returns the parent context, if any
+func (c *Context) Parent() *Context {
+	return c.parentContext
+}
+
 type Args []string
 
 // Returns the command line arguments associated with the context.


### PR DESCRIPTION
Need this for being able to show correct help output for subcommands.
Ie, instead of just `{{.Name}} - {{.Usage}}` we need to be able to do `{{.Parent.Name}} {{.Name}} - {{.Usage}}`