### PR TITLE
Sets a subcommand's parent cmd

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -735,6 +735,36 @@ func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
 	}
 }
 
+func TestApp_Run_SubcommandFullPath(t *testing.T) {
+	app := cli.NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+
+	subCmd := cli.Command{
+		Name:  "bar",
+		Usage: "does bar things",
+	}
+	cmd := cli.Command{
+		Name:        "foo",
+		Description: "foo commands",
+		Subcommands: []cli.Command{subCmd},
+	}
+	app.Commands = []cli.Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "bar", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "foo bar - does bar things") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+	if !strings.Contains(output, "command foo bar [arguments...]") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+}
+
 func TestApp_Run_Help(t *testing.T) {
 	var helpArguments = [][]string{{"boom", "--help"}, {"boom", "-h"}, {"boom", "help"}}
 

--- a/help.go
+++ b/help.go
@@ -20,7 +20,7 @@ USAGE:
 VERSION:
    {{.Version}}
    {{end}}{{if len .Authors}}
-AUTHOR(S): 
+AUTHOR(S):
    {{range .Authors}}{{ . }}{{end}}
    {{end}}{{if .Commands}}
 COMMANDS:
@@ -38,10 +38,10 @@ COPYRIGHT:
 // cli.go uses text/template to render templates. You can
 // render custom help text by setting this variable.
 var CommandHelpTemplate = `NAME:
-   {{.Name}} - {{.Usage}}
+   {{.FullName}} - {{.Usage}}
 
 USAGE:
-   command {{.Name}}{{if .Flags}} [command options]{{end}} [arguments...]{{if .Description}}
+   command {{.FullName}}{{if .Flags}} [command options]{{end}} [arguments...]{{if .Description}}
 
 DESCRIPTION:
    {{.Description}}{{end}}{{if .Flags}}


### PR DESCRIPTION
This allows the help output to show the correct/full command path to the
subcommand.
For instance:
```
BaseCommand
    -> SubCommandA
        -> SubCommandA1
```

Currently the "usage" help output for `SubCommandA1` would look like `BaseCommand SubCommandA1`
When really what it should be is `BaseCommand SubCommandA SubCommandA1`

#245 was originally intended to help solve this problem, unfortunately I submitted that PR a bit too early in the process (so sorry!)

