### PR TITLE
Print blank lines in help and error outputs more consistently.

### DIFF
--- a/app.go
+++ b/app.go
@@ -108,15 +108,14 @@ func (a *App) Run(arguments []string) (err error) {
 		fmt.Fprintln(a.Writer, nerr)
 		context := NewContext(a, set, nil)
 		ShowAppHelp(context)
-		fmt.Fprintln(a.Writer)
 		return nerr
 	}
 	context := NewContext(a, set, nil)
 
 	if err != nil {
-		fmt.Fprintf(a.Writer, "Incorrect Usage.\n\n")
-		ShowAppHelp(context)
+		fmt.Fprintln(a.Writer, "Incorrect Usage.")
 		fmt.Fprintln(a.Writer)
+		ShowAppHelp(context)
 		return err
 	}
 
@@ -200,17 +199,18 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 
 	if nerr != nil {
 		fmt.Fprintln(a.Writer, nerr)
+		fmt.Fprintln(a.Writer)
 		if len(a.Commands) > 0 {
 			ShowSubcommandHelp(context)
 		} else {
 			ShowCommandHelp(ctx, context.Args().First())
 		}
-		fmt.Fprintln(a.Writer)
 		return nerr
 	}
 
 	if err != nil {
-		fmt.Fprintf(a.Writer, "Incorrect Usage.\n\n")
+		fmt.Fprintln(a.Writer, "Incorrect Usage.")
+		fmt.Fprintln(a.Writer)
 		ShowSubcommandHelp(context)
 		return err
 	}

--- a/command.go
+++ b/command.go
@@ -91,9 +91,9 @@ func (c Command) Run(ctx *Context) error {
 	}
 
 	if err != nil {
-		fmt.Fprint(ctx.App.Writer, "Incorrect Usage.\n\n")
-		ShowCommandHelp(ctx, c.Name)
+		fmt.Fprintln(ctx.App.Writer, "Incorrect Usage.")
 		fmt.Fprintln(ctx.App.Writer)
+		ShowCommandHelp(ctx, c.Name)
 		return err
 	}
 
@@ -102,7 +102,6 @@ func (c Command) Run(ctx *Context) error {
 		fmt.Fprintln(ctx.App.Writer, nerr)
 		fmt.Fprintln(ctx.App.Writer)
 		ShowCommandHelp(ctx, c.Name)
-		fmt.Fprintln(ctx.App.Writer)
 		return nerr
 	}
 	context := NewContext(ctx.App, set, ctx)


### PR DESCRIPTION
Usage output is more consistent now in error and non-error cases