### PR TITLE
More cleanups

### DIFF
--- a/app.go
+++ b/app.go
@@ -108,15 +108,14 @@ func (a *App) Run(arguments []string) (err error) {
 		fmt.Fprintln(a.Writer, nerr)
 		context := NewContext(a, set, nil)
 		ShowAppHelp(context)
-		fmt.Fprintln(a.Writer)
 		return nerr
 	}
 	context := NewContext(a, set, nil)
 
 	if err != nil {
-		fmt.Fprintf(a.Writer, "Incorrect Usage.\n\n")
-		ShowAppHelp(context)
+		fmt.Fprintln(a.Writer, "Incorrect Usage.")
 		fmt.Fprintln(a.Writer)
+		ShowAppHelp(context)
 		return err
 	}
 
@@ -200,17 +199,18 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 
 	if nerr != nil {
 		fmt.Fprintln(a.Writer, nerr)
+		fmt.Fprintln(a.Writer)
 		if len(a.Commands) > 0 {
 			ShowSubcommandHelp(context)
 		} else {
 			ShowCommandHelp(ctx, context.Args().First())
 		}
-		fmt.Fprintln(a.Writer)
 		return nerr
 	}
 
 	if err != nil {
-		fmt.Fprintf(a.Writer, "Incorrect Usage.\n\n")
+		fmt.Fprintln(a.Writer, "Incorrect Usage.")
+		fmt.Fprintln(a.Writer)
 		ShowSubcommandHelp(context)
 		return err
 	}

--- a/command.go
+++ b/command.go
@@ -91,9 +91,9 @@ func (c Command) Run(ctx *Context) error {
 	}
 
 	if err != nil {
-		fmt.Fprint(ctx.App.Writer, "Incorrect Usage.\n\n")
-		ShowCommandHelp(ctx, c.Name)
+		fmt.Fprintln(ctx.App.Writer, "Incorrect Usage.")
 		fmt.Fprintln(ctx.App.Writer)
+		ShowCommandHelp(ctx, c.Name)
 		return err
 	}
 
@@ -102,7 +102,6 @@ func (c Command) Run(ctx *Context) error {
 		fmt.Fprintln(ctx.App.Writer, nerr)
 		fmt.Fprintln(ctx.App.Writer)
 		ShowCommandHelp(ctx, c.Name)
-		fmt.Fprintln(ctx.App.Writer)
 		return nerr
 	}
 	context := NewContext(ctx.App, set, ctx)

--- a/help.go
+++ b/help.go
@@ -15,24 +15,23 @@ var AppHelpTemplate = `NAME:
    {{.Name}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} {{if .Flags}}[global options] {{end}}command{{if .Flags}} [command options]{{end}} [arguments...]{{if len .Version}}
-
+   {{.Name}} {{if .Flags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} [arguments...]
+   {{if .Version}}
 VERSION:
-   {{.Version}}{{end}}{{if len .Authors}}
-
+   {{.Version}}
+   {{end}}{{if len .Authors}}
 AUTHOR(S): 
-   {{range .Authors}}{{ . }}{{end}}{{end}}{{if .Commands}}
-
+   {{range .Authors}}{{ . }}{{end}}
+   {{end}}{{if .Commands}}
 COMMANDS:
    {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
    {{end}}{{end}}{{if .Flags}}
-
 GLOBAL OPTIONS:
    {{range .Flags}}{{.}}
    {{end}}{{end}}{{if .Copyright }}
-
 COPYRIGHT:
-   {{.Copyright}}{{end}}
+   {{.Copyright}}
+   {{end}}
 `
 
 // The text template for the command help topic.

--- a/help.go
+++ b/help.go
@@ -21,14 +21,16 @@ VERSION:
    {{.Version}}{{end}}{{if len .Authors}}
 
 AUTHOR(S): 
-   {{range .Authors}}{{ . }}{{end}}{{end}}
+   {{range .Authors}}{{ . }}{{end}}{{end}}{{if .Commands}}
 
 COMMANDS:
    {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
-   {{end}}{{if .Flags}}
+   {{end}}{{end}}{{if .Flags}}
+
 GLOBAL OPTIONS:
    {{range .Flags}}{{.}}
    {{end}}{{end}}{{if .Copyright }}
+
 COPYRIGHT:
    {{.Copyright}}{{end}}
 `

--- a/help.go
+++ b/help.go
@@ -15,10 +15,10 @@ var AppHelpTemplate = `NAME:
    {{.Name}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} {{if .Flags}}[global options] {{end}}command{{if .Flags}} [command options]{{end}} [arguments...]
+   {{.Name}} {{if .Flags}}[global options] {{end}}command{{if .Flags}} [command options]{{end}} [arguments...]{{if len .Version}}
 
 VERSION:
-   {{.Version}}{{if len .Authors}}
+   {{.Version}}{{end}}{{if len .Authors}}
 
 AUTHOR(S): 
    {{range .Authors}}{{ . }}{{end}}{{end}}

--- a/help_test.go
+++ b/help_test.go
@@ -20,3 +20,17 @@ func Test_ShowAppHelp_NoAuthor(t *testing.T) {
 		t.Errorf("expected\n%snot to include %s", output.String(), "AUTHOR(S):")
 	}
 }
+
+func Test_ShowAppHelp_NoVersion(t *testing.T) {
+	output := new(bytes.Buffer)
+	app := cli.NewApp()
+	app.Writer = output
+
+	c := cli.NewContext(app, nil, nil)
+
+	cli.ShowAppHelp(c)
+
+	if bytes.Index(output.Bytes(), []byte("VERSION:")) != -1 {
+		t.Errorf("expected\n%snot to include %s", output.String(), "VERSION:")
+	}
+}

--- a/help_test.go
+++ b/help_test.go
@@ -26,6 +26,8 @@ func Test_ShowAppHelp_NoVersion(t *testing.T) {
 	app := cli.NewApp()
 	app.Writer = output
 
+	app.Version = ""
+
 	c := cli.NewContext(app, nil, nil)
 
 	cli.ShowAppHelp(c)


### PR DESCRIPTION
This adds some formatting cleanups based on issue #248 and handles the case where there are no Commands (don't show the Commands block *and* don't show "command" in the Usage example.)