### PR TITLE
Fix global flags processing on top level

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -627,6 +627,23 @@ func TestAppCommandNotFound(t *testing.T) {
 	expect(t, subcommandRun, false)
 }
 
+func TestGlobalFlag(t *testing.T) {
+	var globalFlag string
+	var globalFlagSet bool
+	app := cli.NewApp()
+	app.Flags = []cli.Flag{
+		cli.StringFlag{Name: "global, g", Usage: "global"},
+	}
+	app.Action = func(c *cli.Context) {
+		globalFlag = c.GlobalString("global")
+		globalFlagSet = c.GlobalIsSet("global")
+	}
+	app.Run([]string{"command", "-g", "foo"})
+	expect(t, globalFlag, "foo")
+	expect(t, globalFlagSet, true)
+
+}
+
 func TestGlobalFlagsInSubcommands(t *testing.T) {
 	subcommandRun := false
 	parentFlag := false


### PR DESCRIPTION
This fixes a regression introduced by #227. When looking up global flags by walking up the parent context's we need to consider the special case when we are starting at the very top and there is no parent context to start the traversal.

Fixes #252

Ping @jszwedko