### PR TITLE
Add website info to the output

### DIFF
--- a/app.go
+++ b/app.go
@@ -17,6 +17,8 @@ type App struct {
 	Usage string
 	// Version of the program
 	Version string
+	// Website of the program
+	Website string
 	// List of commands to execute
 	Commands []Command
 	// List of flags to parse

--- a/help.go
+++ b/help.go
@@ -22,6 +22,9 @@ VERSION:
    {{end}}{{if len .Authors}}
 AUTHOR(S): 
    {{range .Authors}}{{ . }}{{end}}
+   {{end}}{{if .Website}}
+WEBSITE:
+   {{.Website}}
    {{end}}{{if .Commands}}
 COMMANDS:
    {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}


### PR DESCRIPTION
Hi!
I think, it would be great to provide information about website on the output
Usage is a trivial
```go
app := cli.NewApp()
app.Name = "greet"
app.Usage = "fight the loneliness!"
app.Website = "https://github.com/codegangsta/cli/"
```
And output with flag ```-h``` will looks like:
```
NAME:
   greet - fight the loneliness!

USAGE:
   greet [global options] command [command options] [arguments...]
   
VERSION:
   0.0.0
   
WEBSITE:
   https://github.com/codegangsta/cli/
```
What do you think?