### PR TITLE
Added exit code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ export PATH=$PATH:$GOPATH/bin
 ```
 
 ## Getting Started
-One of the philosophies behind cli.go is that an API should be playful and full of discovery. So a cli.go app can be as little as one line of code in `main()`. 
+One of the philosophies behind cli.go is that an API should be playful and full of discovery. So a cli.go app can be as little as one line of code in `main()`.
 
 ``` go
 package main
@@ -57,7 +57,7 @@ func main() {
   app.Action = func(c *cli.Context) {
     println("boom! I say!")
   }
-  
+
   app.Run(os.Args)
 }
 ```
@@ -249,6 +249,28 @@ app.Commands = []cli.Command{
   },
 }
 ...
+```
+
+### Exit code
+
+It is your responsability to call `os.Exit` with the exit code returned by
+`app.Run`
+
+```go
+package main
+
+import (
+  "os"
+  "github.com/codegangsta/cli"
+)
+
+func main() {
+  exitCode, err := cli.NewApp().Run(os.Args)
+  if err != nil {
+    log.Println(err)
+  }
+  os.Exit(exitCode)
+}
 ```
 
 ### Bash Completion

--- a/app.go
+++ b/app.go
@@ -28,17 +28,17 @@ type App struct {
 	// Boolean to hide built-in version flag
 	HideVersion bool
 	// An action to execute when the bash-completion flag is set
-	BashComplete func(context *Context)
+	BashComplete BashCompleteFn
 	// An action to execute before any subcommands are run, but after the context is ready
 	// If a non-nil error is returned, no subcommands are run
-	Before func(context *Context) error
+	Before BeforeFn
 	// An action to execute after any subcommands are run, but after the subcommand has finished
 	// It is run even if Action() panics
-	After func(context *Context) error
+	After AfterFn
 	// The action to execute when no subcommands are specified
-	Action func(context *Context)
+	Action ActionFn
 	// Execute this function if the proper command cannot be found
-	CommandNotFound func(context *Context, command string)
+	CommandNotFound CommandNotFoundFn
 	// Compilation date
 	Compiled time.Time
 	// List of all authors who contributed

--- a/app_test.go
+++ b/app_test.go
@@ -21,8 +21,9 @@ func ExampleApp() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{Name: "name", Value: "bob", Usage: "a name to say"},
 	}
-	app.Action = func(c *cli.Context) {
+	app.Action = func(c *cli.Context) int {
 		fmt.Printf("Hello %v\n", c.String("name"))
+		return 0
 	}
 	app.Author = "Harrison"
 	app.Email = "harrison@lolwut.com"
@@ -56,8 +57,9 @@ func ExampleAppSubcommand() {
 							Usage: "Name of the person to greet",
 						},
 					},
-					Action: func(c *cli.Context) {
+					Action: func(c *cli.Context) int {
 						fmt.Println("Hello,", c.String("name"))
+						return 0
 					},
 				},
 			},
@@ -84,8 +86,9 @@ func ExampleAppHelp() {
 			Aliases:     []string{"d"},
 			Usage:       "use it to see a description",
 			Description: "This is how we describe describeit the function",
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) int {
 				fmt.Printf("i like to describe things")
+				return 0
 			},
 		},
 	}
@@ -114,15 +117,17 @@ func ExampleAppBashComplete() {
 			Aliases:     []string{"d"},
 			Usage:       "use it to see a description",
 			Description: "This is how we describe describeit the function",
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) int {
 				fmt.Printf("i like to describe things")
+				return 0
 			},
 		}, {
 			Name:        "next",
 			Usage:       "next example",
 			Description: "more stuff to see when generating bash completion",
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) int {
 				fmt.Printf("the next example")
+				return 0
 			},
 		},
 	}
@@ -140,14 +145,17 @@ func TestApp_Run(t *testing.T) {
 	s := ""
 
 	app := cli.NewApp()
-	app.Action = func(c *cli.Context) {
+	app.Action = func(c *cli.Context) int {
 		s = s + c.Args().First()
+		return 0
 	}
 
-	err := app.Run([]string{"command", "foo"})
+	ec, err := app.Run([]string{"command", "foo"})
 	expect(t, err, nil)
-	err = app.Run([]string{"command", "bar"})
+	expect(t, ec, 0)
+	ec, err = app.Run([]string{"command", "bar"})
 	expect(t, err, nil)
+	expect(t, ec, 0)
 	expect(t, s, "foobar")
 }
 
@@ -186,9 +194,10 @@ func TestApp_CommandWithArgBeforeFlags(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.StringFlag{Name: "option", Value: "", Usage: "some option"},
 		},
-		Action: func(c *cli.Context) {
+		Action: func(c *cli.Context) int {
 			parsedOption = c.String("option")
 			firstArg = c.Args().First()
+			return 0
 		},
 	}
 	app.Commands = []cli.Command{command}
@@ -206,8 +215,9 @@ func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
 	a.Commands = []cli.Command{
 		{
 			Name: "foo",
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) int {
 				context = c
+				return 0
 			},
 			Flags: []cli.Flag{
 				cli.StringFlag{
@@ -216,7 +226,7 @@ func TestApp_RunAsSubcommandParseFlags(t *testing.T) {
 					Usage: "language for the greeting",
 				},
 			},
-			Before: func(_ *cli.Context) error { return nil },
+			Before: func(_ *cli.Context) (int, error) { return 0, nil },
 		},
 	}
 	a.Run([]string{"", "foo", "--lang", "spanish", "abcd"})
@@ -235,9 +245,10 @@ func TestApp_CommandWithFlagBeforeTerminator(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.StringFlag{Name: "option", Value: "", Usage: "some option"},
 		},
-		Action: func(c *cli.Context) {
+		Action: func(c *cli.Context) int {
 			parsedOption = c.String("option")
 			args = c.Args()
+			return 0
 		},
 	}
 	app.Commands = []cli.Command{command}
@@ -256,8 +267,9 @@ func TestApp_CommandWithNoFlagBeforeTerminator(t *testing.T) {
 	app := cli.NewApp()
 	command := cli.Command{
 		Name: "cmd",
-		Action: func(c *cli.Context) {
+		Action: func(c *cli.Context) int {
 			args = c.Args()
+			return 0
 		},
 	}
 	app.Commands = []cli.Command{command}
@@ -276,8 +288,9 @@ func TestApp_Float64Flag(t *testing.T) {
 	app.Flags = []cli.Flag{
 		cli.Float64Flag{Name: "height", Value: 1.5, Usage: "Set the height, in meters"},
 	}
-	app.Action = func(c *cli.Context) {
+	app.Action = func(c *cli.Context) int {
 		meters = c.Float64("height")
+		return 0
 	}
 
 	app.Run([]string{"", "--height", "1.93"})
@@ -296,11 +309,12 @@ func TestApp_ParseSliceFlags(t *testing.T) {
 			cli.IntSliceFlag{Name: "p", Value: &cli.IntSlice{}, Usage: "set one or more ip addr"},
 			cli.StringSliceFlag{Name: "ip", Value: &cli.StringSlice{}, Usage: "set one or more ports to open"},
 		},
-		Action: func(c *cli.Context) {
+		Action: func(c *cli.Context) int {
 			parsedIntSlice = c.IntSlice("p")
 			parsedStringSlice = c.StringSlice("ip")
 			parsedOption = c.String("option")
 			firstArg = c.Args().First()
+			return 0
 		},
 	}
 	app.Commands = []cli.Command{command}
@@ -353,9 +367,10 @@ func TestApp_ParseSliceFlagsWithMissingValue(t *testing.T) {
 			cli.IntSliceFlag{Name: "a", Usage: "set numbers"},
 			cli.StringSliceFlag{Name: "str", Usage: "set strings"},
 		},
-		Action: func(c *cli.Context) {
+		Action: func(c *cli.Context) int {
 			parsedIntSlice = c.IntSlice("a")
 			parsedStringSlice = c.StringSlice("str")
+			return 0
 		},
 	}
 	app.Commands = []cli.Command{command}
@@ -407,7 +422,7 @@ func TestApp_SetStdout(t *testing.T) {
 	app.Name = "test"
 	app.Writer = w
 
-	err := app.Run([]string{"help"})
+	_, err := app.Run([]string{"help"})
 
 	if err != nil {
 		t.Fatalf("Run error: %s", err)
@@ -425,21 +440,22 @@ func TestApp_BeforeFunc(t *testing.T) {
 
 	app := cli.NewApp()
 
-	app.Before = func(c *cli.Context) error {
+	app.Before = func(c *cli.Context) (int, error) {
 		beforeRun = true
 		s := c.String("opt")
 		if s == "fail" {
-			return beforeError
+			return 1, beforeError
 		}
 
-		return nil
+		return 0, nil
 	}
 
 	app.Commands = []cli.Command{
 		cli.Command{
 			Name: "sub",
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) int {
 				subcommandRun = true
+				return 0
 			},
 		},
 	}
@@ -449,7 +465,7 @@ func TestApp_BeforeFunc(t *testing.T) {
 	}
 
 	// run with the Before() func succeeding
-	err = app.Run([]string{"command", "--opt", "succeed", "sub"})
+	ec, err := app.Run([]string{"command", "--opt", "succeed", "sub"})
 
 	if err != nil {
 		t.Fatalf("Run error: %s", err)
@@ -463,11 +479,15 @@ func TestApp_BeforeFunc(t *testing.T) {
 		t.Errorf("Subcommand not executed when expected")
 	}
 
+	if ec != 0 {
+		t.Errorf("Expected exit code to be %d but got %d", 0, ec)
+	}
+
 	// reset
 	beforeRun, subcommandRun = false, false
 
 	// run with the Before() func failing
-	err = app.Run([]string{"command", "--opt", "fail", "sub"})
+	ec, err = app.Run([]string{"command", "--opt", "fail", "sub"})
 
 	// should be the same error produced by the Before func
 	if err != beforeError {
@@ -482,6 +502,9 @@ func TestApp_BeforeFunc(t *testing.T) {
 		t.Errorf("Subcommand executed when NOT expected")
 	}
 
+	if ec != 1 {
+		t.Errorf("Expected exit code to be %d but got %d", 1, ec)
+	}
 }
 
 func TestApp_AfterFunc(t *testing.T) {
@@ -491,21 +514,22 @@ func TestApp_AfterFunc(t *testing.T) {
 
 	app := cli.NewApp()
 
-	app.After = func(c *cli.Context) error {
+	app.After = func(c *cli.Context) (int, error) {
 		afterRun = true
 		s := c.String("opt")
 		if s == "fail" {
-			return afterError
+			return 1, afterError
 		}
 
-		return nil
+		return 0, nil
 	}
 
 	app.Commands = []cli.Command{
 		cli.Command{
 			Name: "sub",
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) int {
 				subcommandRun = true
+				return 0
 			},
 		},
 	}
@@ -515,7 +539,7 @@ func TestApp_AfterFunc(t *testing.T) {
 	}
 
 	// run with the After() func succeeding
-	err = app.Run([]string{"command", "--opt", "succeed", "sub"})
+	ec, err := app.Run([]string{"command", "--opt", "succeed", "sub"})
 
 	if err != nil {
 		t.Fatalf("Run error: %s", err)
@@ -529,11 +553,15 @@ func TestApp_AfterFunc(t *testing.T) {
 		t.Errorf("Subcommand not executed when expected")
 	}
 
+	if ec != 0 {
+		t.Errorf("Expected exit code to be %d but got %d", 0, ec)
+	}
+
 	// reset
 	afterRun, subcommandRun = false, false
 
 	// run with the Before() func failing
-	err = app.Run([]string{"command", "--opt", "fail", "sub"})
+	ec, err = app.Run([]string{"command", "--opt", "fail", "sub"})
 
 	// should be the same error produced by the Before func
 	if err != afterError {
@@ -547,6 +575,10 @@ func TestApp_AfterFunc(t *testing.T) {
 	if subcommandRun == false {
 		t.Errorf("Subcommand not executed when expected")
 	}
+
+	if ec != 1 {
+		t.Errorf("Expected exit code to be %d but got %d", 1, ec)
+	}
 }
 
 func TestAppNoHelpFlag(t *testing.T) {
@@ -558,7 +590,7 @@ func TestAppNoHelpFlag(t *testing.T) {
 	cli.HelpFlag = cli.BoolFlag{}
 
 	app := cli.NewApp()
-	err := app.Run([]string{"test", "-h"})
+	_, err := app.Run([]string{"test", "-h"})
 
 	if err != flag.ErrHelp {
 		t.Errorf("expected error about missing help flag, but got: %s (%T)", err, err)
@@ -615,8 +647,9 @@ func TestAppCommandNotFound(t *testing.T) {
 	app.Commands = []cli.Command{
 		cli.Command{
 			Name: "bar",
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) int {
 				subcommandRun = true
+				return 0
 			},
 		},
 	}
@@ -634,9 +667,10 @@ func TestGlobalFlag(t *testing.T) {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{Name: "global, g", Usage: "global"},
 	}
-	app.Action = func(c *cli.Context) {
+	app.Action = func(c *cli.Context) int {
 		globalFlag = c.GlobalString("global")
 		globalFlagSet = c.GlobalIsSet("global")
+		return 0
 	}
 	app.Run([]string{"command", "-g", "foo"})
 	expect(t, globalFlag, "foo")
@@ -662,13 +696,14 @@ func TestGlobalFlagsInSubcommands(t *testing.T) {
 			Subcommands: []cli.Command{
 				{
 					Name: "bar",
-					Action: func(c *cli.Context) {
+					Action: func(c *cli.Context) int {
 						if c.GlobalBool("debug") {
 							subcommandRun = true
 						}
 						if c.GlobalBool("parent") {
 							parentFlag = true
 						}
+						return 0
 					},
 				},
 			},
@@ -710,7 +745,7 @@ func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
 		}
 
 		app.Commands = []cli.Command{cmd}
-		err := app.Run(flagSet)
+		_, err := app.Run(flagSet)
 
 		if err != nil {
 			t.Error(err)
@@ -751,7 +786,7 @@ func TestApp_Run_SubcommandFullPath(t *testing.T) {
 	}
 	app.Commands = []cli.Command{cmd}
 
-	err := app.Run([]string{"command", "foo", "bar", "--help"})
+	_, err := app.Run([]string{"command", "foo", "bar", "--help"})
 	if err != nil {
 		t.Error(err)
 	}
@@ -777,11 +812,12 @@ func TestApp_Run_Help(t *testing.T) {
 		app.Name = "boom"
 		app.Usage = "make an explosive entrance"
 		app.Writer = buf
-		app.Action = func(c *cli.Context) {
+		app.Action = func(c *cli.Context) int {
 			buf.WriteString("boom I say!")
+			return 0
 		}
 
-		err := app.Run(args)
+		_, err := app.Run(args)
 		if err != nil {
 			t.Error(err)
 		}
@@ -808,11 +844,12 @@ func TestApp_Run_Version(t *testing.T) {
 		app.Usage = "make an explosive entrance"
 		app.Version = "0.1.0"
 		app.Writer = buf
-		app.Action = func(c *cli.Context) {
+		app.Action = func(c *cli.Context) int {
 			buf.WriteString("boom I say!")
+			return 0
 		}
 
-		err := app.Run(args)
+		_, err := app.Run(args)
 		if err != nil {
 			t.Error(err)
 		}
@@ -828,11 +865,11 @@ func TestApp_Run_Version(t *testing.T) {
 
 func TestApp_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 	app := cli.NewApp()
-	app.Action = func(c *cli.Context) {}
-	app.Before = func(c *cli.Context) error { return fmt.Errorf("before error") }
-	app.After = func(c *cli.Context) error { return fmt.Errorf("after error") }
+	app.Action = func(c *cli.Context) int { return 0 }
+	app.Before = func(c *cli.Context) (int, error) { return 1, fmt.Errorf("before error") }
+	app.After = func(c *cli.Context) (int, error) { return 2, fmt.Errorf("after error") }
 
-	err := app.Run([]string{"foo"})
+	ec, err := app.Run([]string{"foo"})
 	if err == nil {
 		t.Fatalf("expected to recieve error from Run, got none")
 	}
@@ -842,6 +879,10 @@ func TestApp_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "after error") {
 		t.Errorf("expected text of error from After method, but got none in \"%v\"", err)
+	}
+
+	if ec != 2 {
+		t.Errorf("Expected exit code to be %d but got %d", 2, ec)
 	}
 }
 
@@ -850,12 +891,12 @@ func TestApp_Run_SubcommandDoesNotOverwriteErrorFromBefore(t *testing.T) {
 	app.Commands = []cli.Command{
 		cli.Command{
 			Name:   "bar",
-			Before: func(c *cli.Context) error { return fmt.Errorf("before error") },
-			After:  func(c *cli.Context) error { return fmt.Errorf("after error") },
+			Before: func(c *cli.Context) (int, error) { return 1, fmt.Errorf("before error") },
+			After:  func(c *cli.Context) (int, error) { return 2, fmt.Errorf("after error") },
 		},
 	}
 
-	err := app.Run([]string{"foo", "bar"})
+	ec, err := app.Run([]string{"foo", "bar"})
 	if err == nil {
 		t.Fatalf("expected to recieve error from Run, got none")
 	}
@@ -865,5 +906,9 @@ func TestApp_Run_SubcommandDoesNotOverwriteErrorFromBefore(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "after error") {
 		t.Errorf("expected text of error from After method, but got none in \"%v\"", err)
+	}
+
+	if ec != 2 {
+		t.Errorf("Expected exit code to be %d but got %d", 2, ec)
 	}
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -15,16 +15,18 @@ func Example() {
 			Name:    "add",
 			Aliases: []string{"a"},
 			Usage:   "add a task to the list",
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) int {
 				println("added task: ", c.Args().First())
+				return 0
 			},
 		},
 		{
 			Name:    "complete",
 			Aliases: []string{"c"},
 			Usage:   "complete a task on the list",
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) int {
 				println("completed task: ", c.Args().First())
+				return 0
 			},
 		},
 	}
@@ -54,8 +56,9 @@ func ExampleSubcommand() {
 							Usage: "Name of the person to greet",
 						},
 					},
-					Action: func(c *cli.Context) {
+					Action: func(c *cli.Context) int {
 						println("Hello, ", c.String("name"))
+						return 0
 					},
 				}, {
 					Name:    "spanish",
@@ -68,8 +71,9 @@ func ExampleSubcommand() {
 							Usage: "Surname of the person to greet",
 						},
 					},
-					Action: func(c *cli.Context) {
+					Action: func(c *cli.Context) int {
 						println("Hola, ", c.String("surname"))
+						return 0
 					},
 				}, {
 					Name:    "french",
@@ -82,16 +86,18 @@ func ExampleSubcommand() {
 							Usage: "Nickname of the person to greet",
 						},
 					},
-					Action: func(c *cli.Context) {
+					Action: func(c *cli.Context) int {
 						println("Bonjour, ", c.String("nickname"))
+						return 0
 					},
 				},
 			},
 		}, {
 			Name:  "bye",
 			Usage: "says goodbye",
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) int {
 				println("bye")
+				return 0
 			},
 		},
 	}

--- a/command.go
+++ b/command.go
@@ -19,15 +19,15 @@ type Command struct {
 	// A longer explanation of how the command works
 	Description string
 	// The function to call when checking for bash command completions
-	BashComplete func(context *Context)
+	BashComplete BashCompleteFn
 	// An action to execute before any sub-subcommands are run, but after the context is ready
 	// If a non-nil error is returned, no sub-subcommands are run
-	Before func(context *Context) error
+	Before BeforeFn
 	// An action to execute after any subcommands are run, but after the subcommand has finished
 	// It is run even if Action() panics
-	After func(context *Context) error
+	After AfterFn
 	// The function to call when this command is invoked
-	Action func(context *Context)
+	Action ActionFn
 	// List of child commands
 	Subcommands []Command
 	// List of flags to parse

--- a/command.go
+++ b/command.go
@@ -50,7 +50,7 @@ func (c Command) FullName() string {
 }
 
 // Invokes the command given the context, parses ctx.Args() to generate command-specific flags
-func (c Command) Run(ctx *Context) error {
+func (c Command) Run(ctx *Context) (int, error) {
 	if len(c.Subcommands) > 0 || c.Before != nil || c.After != nil {
 		return c.startApp(ctx)
 	}
@@ -104,7 +104,7 @@ func (c Command) Run(ctx *Context) error {
 		fmt.Fprintln(ctx.App.Writer, "Incorrect Usage.")
 		fmt.Fprintln(ctx.App.Writer)
 		ShowCommandHelp(ctx, c.Name)
-		return err
+		return DefaultExitCode, err
 	}
 
 	nerr := normalizeFlags(c.Flags, set)
@@ -112,20 +112,19 @@ func (c Command) Run(ctx *Context) error {
 		fmt.Fprintln(ctx.App.Writer, nerr)
 		fmt.Fprintln(ctx.App.Writer)
 		ShowCommandHelp(ctx, c.Name)
-		return nerr
+		return DefaultExitCode, nerr
 	}
 	context := NewContext(ctx.App, set, ctx)
 
 	if checkCommandCompletions(context, c.Name) {
-		return nil
+		return 0, nil
 	}
 
 	if checkCommandHelp(context, c.Name) {
-		return nil
+		return 0, nil
 	}
 	context.Command = c
-	c.Action(context)
-	return nil
+	return c.Action(context), nil
 }
 
 func (c Command) Names() []string {
@@ -148,7 +147,7 @@ func (c Command) HasName(name string) bool {
 	return false
 }
 
-func (c Command) startApp(ctx *Context) error {
+func (c Command) startApp(ctx *Context) (int, error) {
 	app := NewApp()
 
 	// set the name and usage

--- a/command_test.go
+++ b/command_test.go
@@ -20,9 +20,9 @@ func TestCommandDoNotIgnoreFlags(t *testing.T) {
 		Aliases:     []string{"tc"},
 		Usage:       "this is for testing",
 		Description: "testing",
-		Action:      func(_ *cli.Context) {},
+		Action:      func(_ *cli.Context) int { return 0 },
 	}
-	err := command.Run(c)
+	_, err := command.Run(c)
 
 	expect(t, err.Error(), "flag provided but not defined: -break")
 }
@@ -40,10 +40,10 @@ func TestCommandIgnoreFlags(t *testing.T) {
 		Aliases:         []string{"tc"},
 		Usage:           "this is for testing",
 		Description:     "testing",
-		Action:          func(_ *cli.Context) {},
+		Action:          func(_ *cli.Context) int { return 0 },
 		SkipFlagParsing: true,
 	}
-	err := command.Run(c)
+	_, err := command.Run(c)
 
 	expect(t, err, nil)
 }

--- a/flag_test.go
+++ b/flag_test.go
@@ -296,13 +296,14 @@ func TestParseMultiString(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.StringFlag{Name: "serve, s"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.String("serve") != "10" {
 				t.Errorf("main name not set")
 			}
 			if ctx.String("s") != "10" {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}).Run([]string{"run", "-s", "10"})
 }
@@ -314,13 +315,14 @@ func TestParseMultiStringFromEnv(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.StringFlag{Name: "count, c", EnvVar: "APP_COUNT"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.String("count") != "20" {
 				t.Errorf("main name not set")
 			}
 			if ctx.String("c") != "20" {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}).Run([]string{"run"})
 }
@@ -332,13 +334,14 @@ func TestParseMultiStringFromEnvCascade(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.StringFlag{Name: "count, c", EnvVar: "COMPAT_COUNT,APP_COUNT"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.String("count") != "20" {
 				t.Errorf("main name not set")
 			}
 			if ctx.String("c") != "20" {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}).Run([]string{"run"})
 }
@@ -348,13 +351,14 @@ func TestParseMultiStringSlice(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.StringSliceFlag{Name: "serve, s", Value: &cli.StringSlice{}},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if !reflect.DeepEqual(ctx.StringSlice("serve"), []string{"10", "20"}) {
 				t.Errorf("main name not set")
 			}
 			if !reflect.DeepEqual(ctx.StringSlice("s"), []string{"10", "20"}) {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}).Run([]string{"run", "-s", "10", "-s", "20"})
 }
@@ -367,13 +371,14 @@ func TestParseMultiStringSliceFromEnv(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.StringSliceFlag{Name: "intervals, i", Value: &cli.StringSlice{}, EnvVar: "APP_INTERVALS"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
 				t.Errorf("main name not set from env")
 			}
 			if !reflect.DeepEqual(ctx.StringSlice("i"), []string{"20", "30", "40"}) {
 				t.Errorf("short name not set from env")
 			}
+			return 0
 		},
 	}).Run([]string{"run"})
 }
@@ -386,13 +391,14 @@ func TestParseMultiStringSliceFromEnvCascade(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.StringSliceFlag{Name: "intervals, i", Value: &cli.StringSlice{}, EnvVar: "COMPAT_INTERVALS,APP_INTERVALS"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
 				t.Errorf("main name not set from env")
 			}
 			if !reflect.DeepEqual(ctx.StringSlice("i"), []string{"20", "30", "40"}) {
 				t.Errorf("short name not set from env")
 			}
+			return 0
 		},
 	}).Run([]string{"run"})
 }
@@ -402,13 +408,14 @@ func TestParseMultiInt(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.IntFlag{Name: "serve, s"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.Int("serve") != 10 {
 				t.Errorf("main name not set")
 			}
 			if ctx.Int("s") != 10 {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run", "-s", "10"})
@@ -421,13 +428,14 @@ func TestParseMultiIntFromEnv(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.IntFlag{Name: "timeout, t", EnvVar: "APP_TIMEOUT_SECONDS"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.Int("timeout") != 10 {
 				t.Errorf("main name not set")
 			}
 			if ctx.Int("t") != 10 {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run"})
@@ -440,13 +448,14 @@ func TestParseMultiIntFromEnvCascade(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.IntFlag{Name: "timeout, t", EnvVar: "COMPAT_TIMEOUT_SECONDS,APP_TIMEOUT_SECONDS"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.Int("timeout") != 10 {
 				t.Errorf("main name not set")
 			}
 			if ctx.Int("t") != 10 {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run"})
@@ -457,13 +466,14 @@ func TestParseMultiIntSlice(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.IntSliceFlag{Name: "serve, s", Value: &cli.IntSlice{}},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if !reflect.DeepEqual(ctx.IntSlice("serve"), []int{10, 20}) {
 				t.Errorf("main name not set")
 			}
 			if !reflect.DeepEqual(ctx.IntSlice("s"), []int{10, 20}) {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}).Run([]string{"run", "-s", "10", "-s", "20"})
 }
@@ -476,13 +486,14 @@ func TestParseMultiIntSliceFromEnv(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.IntSliceFlag{Name: "intervals, i", Value: &cli.IntSlice{}, EnvVar: "APP_INTERVALS"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if !reflect.DeepEqual(ctx.IntSlice("intervals"), []int{20, 30, 40}) {
 				t.Errorf("main name not set from env")
 			}
 			if !reflect.DeepEqual(ctx.IntSlice("i"), []int{20, 30, 40}) {
 				t.Errorf("short name not set from env")
 			}
+			return 0
 		},
 	}).Run([]string{"run"})
 }
@@ -495,13 +506,14 @@ func TestParseMultiIntSliceFromEnvCascade(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.IntSliceFlag{Name: "intervals, i", Value: &cli.IntSlice{}, EnvVar: "COMPAT_INTERVALS,APP_INTERVALS"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if !reflect.DeepEqual(ctx.IntSlice("intervals"), []int{20, 30, 40}) {
 				t.Errorf("main name not set from env")
 			}
 			if !reflect.DeepEqual(ctx.IntSlice("i"), []int{20, 30, 40}) {
 				t.Errorf("short name not set from env")
 			}
+			return 0
 		},
 	}).Run([]string{"run"})
 }
@@ -511,13 +523,14 @@ func TestParseMultiFloat64(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.Float64Flag{Name: "serve, s"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.Float64("serve") != 10.2 {
 				t.Errorf("main name not set")
 			}
 			if ctx.Float64("s") != 10.2 {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run", "-s", "10.2"})
@@ -530,13 +543,14 @@ func TestParseMultiFloat64FromEnv(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.Float64Flag{Name: "timeout, t", EnvVar: "APP_TIMEOUT_SECONDS"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.Float64("timeout") != 15.5 {
 				t.Errorf("main name not set")
 			}
 			if ctx.Float64("t") != 15.5 {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run"})
@@ -549,13 +563,14 @@ func TestParseMultiFloat64FromEnvCascade(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.Float64Flag{Name: "timeout, t", EnvVar: "COMPAT_TIMEOUT_SECONDS,APP_TIMEOUT_SECONDS"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.Float64("timeout") != 15.5 {
 				t.Errorf("main name not set")
 			}
 			if ctx.Float64("t") != 15.5 {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run"})
@@ -566,13 +581,14 @@ func TestParseMultiBool(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "serve, s"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.Bool("serve") != true {
 				t.Errorf("main name not set")
 			}
 			if ctx.Bool("s") != true {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run", "--serve"})
@@ -585,13 +601,14 @@ func TestParseMultiBoolFromEnv(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "debug, d", EnvVar: "APP_DEBUG"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.Bool("debug") != true {
 				t.Errorf("main name not set from env")
 			}
 			if ctx.Bool("d") != true {
 				t.Errorf("short name not set from env")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run"})
@@ -604,13 +621,14 @@ func TestParseMultiBoolFromEnvCascade(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "debug, d", EnvVar: "COMPAT_DEBUG,APP_DEBUG"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.Bool("debug") != true {
 				t.Errorf("main name not set from env")
 			}
 			if ctx.Bool("d") != true {
 				t.Errorf("short name not set from env")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run"})
@@ -621,13 +639,14 @@ func TestParseMultiBoolT(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.BoolTFlag{Name: "serve, s"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.BoolT("serve") != true {
 				t.Errorf("main name not set")
 			}
 			if ctx.BoolT("s") != true {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run", "--serve"})
@@ -640,13 +659,14 @@ func TestParseMultiBoolTFromEnv(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.BoolTFlag{Name: "debug, d", EnvVar: "APP_DEBUG"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.BoolT("debug") != false {
 				t.Errorf("main name not set from env")
 			}
 			if ctx.BoolT("d") != false {
 				t.Errorf("short name not set from env")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run"})
@@ -659,13 +679,14 @@ func TestParseMultiBoolTFromEnvCascade(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.BoolTFlag{Name: "debug, d", EnvVar: "COMPAT_DEBUG,APP_DEBUG"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if ctx.BoolT("debug") != false {
 				t.Errorf("main name not set from env")
 			}
 			if ctx.BoolT("d") != false {
 				t.Errorf("short name not set from env")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run"})
@@ -694,13 +715,14 @@ func TestParseGeneric(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.GenericFlag{Name: "serve, s", Value: &Parser{}},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if !reflect.DeepEqual(ctx.Generic("serve"), &Parser{"10", "20"}) {
 				t.Errorf("main name not set")
 			}
 			if !reflect.DeepEqual(ctx.Generic("s"), &Parser{"10", "20"}) {
 				t.Errorf("short name not set")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run", "-s", "10,20"})
@@ -713,13 +735,14 @@ func TestParseGenericFromEnv(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.GenericFlag{Name: "serve, s", Value: &Parser{}, EnvVar: "APP_SERVE"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if !reflect.DeepEqual(ctx.Generic("serve"), &Parser{"20", "30"}) {
 				t.Errorf("main name not set from env")
 			}
 			if !reflect.DeepEqual(ctx.Generic("s"), &Parser{"20", "30"}) {
 				t.Errorf("short name not set from env")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run"})
@@ -732,10 +755,11 @@ func TestParseGenericFromEnvCascade(t *testing.T) {
 		Flags: []cli.Flag{
 			cli.GenericFlag{Name: "foos", Value: &Parser{}, EnvVar: "COMPAT_FOO,APP_FOO"},
 		},
-		Action: func(ctx *cli.Context) {
+		Action: func(ctx *cli.Context) int {
 			if !reflect.DeepEqual(ctx.Generic("foos"), &Parser{"99", "2000"}) {
 				t.Errorf("value not set from env")
 			}
+			return 0
 		},
 	}
 	a.Run([]string{"run"})

--- a/funcs.go
+++ b/funcs.go
@@ -5,14 +5,14 @@ type BashCompleteFn func(*Context)
 
 // An action to execute before any subcommands are run, but after the context is ready
 // If a non-nil error is returned, no subcommands are run
-type BeforeFn func(*Context) error
+type BeforeFn func(*Context) (int, error)
 
 // An action to execute after any subcommands are run, but after the subcommand has finished
 // It is run even if Action() panics
-type AfterFn func(*Context) error
+type AfterFn func(*Context) (int, error)
 
 // The action to execute when no subcommands are specified
-type ActionFn func(*Context)
+type ActionFn func(*Context) int
 
 // Execute this function if the proper command cannot be found
 type CommandNotFoundFn func(*Context, string)

--- a/funcs.go
+++ b/funcs.go
@@ -1,0 +1,18 @@
+package cli
+
+// An action to execute when the bash-completion flag is set
+type BashCompleteFn func(*Context)
+
+// An action to execute before any subcommands are run, but after the context is ready
+// If a non-nil error is returned, no subcommands are run
+type BeforeFn func(*Context) error
+
+// An action to execute after any subcommands are run, but after the subcommand has finished
+// It is run even if Action() panics
+type AfterFn func(*Context) error
+
+// The action to execute when no subcommands are specified
+type ActionFn func(*Context)
+
+// Execute this function if the proper command cannot be found
+type CommandNotFoundFn func(*Context, string)

--- a/help.go
+++ b/help.go
@@ -72,13 +72,14 @@ var helpCommand = Command{
 	Name:    "help",
 	Aliases: []string{"h"},
 	Usage:   "Shows a list of commands or help for one command",
-	Action: func(c *Context) {
+	Action: func(c *Context) int {
 		args := c.Args()
 		if args.Present() {
 			ShowCommandHelp(c, args.First())
 		} else {
 			ShowAppHelp(c)
 		}
+		return 0
 	},
 }
 
@@ -86,13 +87,14 @@ var helpSubcommand = Command{
 	Name:    "help",
 	Aliases: []string{"h"},
 	Usage:   "Shows a list of commands or help for one command",
-	Action: func(c *Context) {
+	Action: func(c *Context) int {
 		args := c.Args()
 		if args.Present() {
 			ShowCommandHelp(c, args.First())
 		} else {
 			ShowSubcommandHelp(c)
 		}
+		return 0
 	},
 }
 


### PR DESCRIPTION
Now the exit code can be returned by BeforeFn, ActionFn and AfterFn.

The `os.Exit` function is not called by this packaged

This closes #66 and closes #164