### PR TITLE
Set default PROG in bash_autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,12 +293,19 @@ setting the `PROG` variable to the name of your program:
 
 #### To Distribute
 
-Copy and modify `autocomplete/bash_autocomplete` to use your program name
-rather than `$PROG` and have the user copy the file into
-`/etc/bash_completion.d/` (or automatically install it there if you are
-distributing a package). Alternatively you can just document that users should
-source the generic `autocomplete/bash_autocomplete` with `$PROG` set to your
-program name in their bash configuration.
+Copy `autocomplete/bash_autocomplete` into `/etc/bash_completion.d/` and rename
+it to the name of the program you wish to add autocomplete support for (or
+automatically install it there if you are distributing a package). Don't forget
+to source the file to make it active in the current shell.
+
+```
+   sudo cp src/bash_autocomplete /etc/bash_completion.d/<myprogram>
+   source /etc/bash_completion.d/<myprogram>
+```
+
+Alternatively, you can just document that users should source the generic
+`autocomplete/bash_autocomplete` in their bash configuration with `$PROG` set
+to the name of their program (as above).
 
 ## Contribution Guidelines
 Feel free to put up a pull request to fix a bug or maybe add a feature. I will give it a code review and make sure that it does not break backwards compatibility. If I or any other collaborators agree that it is in line with the vision of the project, we will work with you to get the code into a mergeable state and merge it into the master branch.

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
 _cli_bash_autocomplete() {
      local cur prev opts base
      COMPREPLY=()


### PR DESCRIPTION
By setting the default value of PROG to the basname of whatever the
filename is, we allow bash_autocomplete to be copied into
/etc/bash_completion.d without modification.