### PR TITLE
Do not return error when flag parsing should be skipped

### DIFF
--- a/command.go
+++ b/command.go
@@ -98,6 +98,12 @@ func (c Command) Run(ctx *Context) error {
 		err = set.Parse(append(flagArgs, regularArgs...))
 	} else {
 		err = set.Parse(ctx.Args().Tail())
+
+		// Work around issue where if the first arg in ctx.Args.Tail()
+		// is a flag, set.Parse returns an error
+		if c.SkipFlagParsing {
+			err = nil
+		}
 	}
 
 	if err != nil {

--- a/command_test.go
+++ b/command_test.go
@@ -45,3 +45,25 @@ func TestCommandIgnoreFlags(t *testing.T) {
 
 	expect(t, err, nil)
 }
+
+// Fix bug with ignoring flag parsing that would still parse the first flag
+func TestCommandIgnoreFlagsIncludingFirstArgument(t *testing.T) {
+	app := NewApp()
+	set := flag.NewFlagSet("test", 0)
+	test := []string{"blah", "-break"}
+	set.Parse(test)
+
+	c := NewContext(app, set, nil)
+
+	command := Command{
+		Name:            "test-cmd",
+		Aliases:         []string{"tc"},
+		Usage:           "this is for testing",
+		Description:     "testing",
+		Action:          func(_ *Context) {},
+		SkipFlagParsing: true,
+	}
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}


### PR DESCRIPTION
Closes #208 

cc @codegangsta @jszwedko 

FWIW I'm not in favor of removing `SkipFlagParsing` in general as it's proven useful in a couple of situations for us so far.  Granted, that may not be the best thing for all users.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>