### PR TITLE
Honor HideHelp and HideVersion

### DIFF
--- a/app.go
+++ b/app.go
@@ -123,11 +123,11 @@ func (a *App) Run(arguments []string) (err error) {
 		return nil
 	}
 
-	if checkHelp(context) {
+	if !a.HideHelp && checkHelp(context) {
 		return nil
 	}
 
-	if checkVersion(context) {
+	if !a.HideVersion && checkVersion(context) {
 		return nil
 	}
 


### PR DESCRIPTION
App.Run does not check a.Hide{Help,Version} before checking help or version,
as a result customers cannot define their own -v flag (e.g. for verbose)