### PR TITLE
Remove 'bitchass' from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ $ greet
 Hello friend!
 ```
 
-`cli.go` also generates some bitchass help text:
+`cli.go` also generates neat help text:
 
 ```
 $ greet help


### PR DESCRIPTION
Having needless derogatory words in the description of the project is just juvenile, and this stood out as a blemish on an otherwise pretty flawless introduction.