### PR TITLE
only display app version and help message once

### DIFF
--- a/app.go
+++ b/app.go
@@ -138,10 +138,12 @@ func (a *App) Run(arguments []string) (err error) {
 	}
 
 	if !a.HideHelp && checkHelp(context) {
+		ShowAppHelp(context)
 		return nil
 	}
 
 	if !a.HideVersion && checkVersion(context) {
+		ShowVersion(context)
 		return nil
 	}
 

--- a/help.go
+++ b/help.go
@@ -190,7 +190,6 @@ func checkVersion(c *Context) bool {
 	if VersionFlag.Name != "" {
 		eachName(VersionFlag.Name, func(name string) {
 			if c.GlobalBool(name) || c.Bool(name) {
-				ShowVersion(c)
 				found = true
 			}
 		})
@@ -203,7 +202,6 @@ func checkHelp(c *Context) bool {
 	if HelpFlag.Name != "" {
 		eachName(HelpFlag.Name, func(name string) {
 			if c.GlobalBool(name) || c.Bool(name) {
-				ShowAppHelp(c)
 				found = true
 			}
 		})


### PR DESCRIPTION
When processing the flags for -h/--help and -v/--version, only check
the flags in checkVersion() and checkHelp() instead of also printing
the associated message.

This fixes the problem of `app -h` and `app -v` printing their output
twice. The doubling was caused by printing the message once for each
registred alias for the given flags (-h/--help and -v/--version).

Resolves #285