### PR TITLE
Added command to have a custom text on the USAGE section of help

### DIFF
--- a/app.go
+++ b/app.go
@@ -17,6 +17,8 @@ type App struct {
 	HelpName string
 	// Description of the program.
 	Usage string
+	// Text to override the USAGE section of help
+	UsageText string
 	// Description of the program argument format.
 	ArgsUsage string
 	// Version of the program
@@ -73,6 +75,7 @@ func NewApp() *App {
 		Name:         os.Args[0],
 		HelpName:     os.Args[0],
 		Usage:        "A new cli application",
+		UsageText:    "",
 		Version:      "0.0.0",
 		BashComplete: DefaultAppComplete,
 		Action:       helpCommand.Action,

--- a/app_test.go
+++ b/app_test.go
@@ -22,6 +22,7 @@ func ExampleApp() {
 	app.Action = func(c *Context) {
 		fmt.Printf("Hello %v\n", c.String("name"))
 	}
+	app.UsageText = "app [first_arg] [second_arg]"
 	app.Author = "Harrison"
 	app.Email = "harrison@lolwut.com"
 	app.Authors = []Author{Author{Name: "Oliver Allen", Email: "oliver@toyshop.com"}}

--- a/command.go
+++ b/command.go
@@ -16,6 +16,8 @@ type Command struct {
 	Aliases []string
 	// A short description of the usage of this command
 	Usage string
+	// Custom text to show on USAGE section of help
+	UsageText string
 	// A longer explanation of how the command works
 	Description string
 	// A short description of the arguments of this command

--- a/help.go
+++ b/help.go
@@ -15,7 +15,7 @@ var AppHelpTemplate = `NAME:
    {{.Name}} - {{.Usage}}
 
 USAGE:
-   {{.HelpName}} {{if .Flags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .Flags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}
    {{if .Version}}
 VERSION:
    {{.Version}}


### PR DESCRIPTION
Setting app.UsageText will override the USAGE section text of help menu with the set string.