### PR TITLE
Use a test table and add --help test

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -1,70 +1,43 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"testing"
 )
 
-func TestCommandDoNotIgnoreFlags(t *testing.T) {
-	app := NewApp()
-	set := flag.NewFlagSet("test", 0)
-	test := []string{"blah", "blah", "-break"}
-	set.Parse(test)
-
-	c := NewContext(app, set, nil)
-
-	command := Command{
-		Name:        "test-cmd",
-		Aliases:     []string{"tc"},
-		Usage:       "this is for testing",
-		Description: "testing",
-		Action:      func(_ *Context) {},
+func TestCommandFlagParsing(t *testing.T) {
+	cases := []struct {
+		testArgs        []string
+		skipFlagParsing bool
+		expectedErr     error
+	}{
+		{[]string{"blah", "blah", "-break"}, false, errors.New("flag provided but not defined: -break")}, // Test normal "not ignoring flags" flow
+		{[]string{"blah", "blah"}, true, nil},                                                            // Test SkipFlagParsing without any args that look like flags
+		{[]string{"blah", "-break"}, true, nil},                                                          // Test SkipFlagParsing with random flag arg
+		{[]string{"blah", "-help"}, true, nil},                                                           // Test SkipFlagParsing with "special" help flag arg
 	}
-	err := command.Run(c)
 
-	expect(t, err.Error(), "flag provided but not defined: -break")
-}
+	for _, c := range cases {
+		app := NewApp()
+		set := flag.NewFlagSet("test", 0)
+		set.Parse(c.testArgs)
 
-func TestCommandIgnoreFlags(t *testing.T) {
-	app := NewApp()
-	set := flag.NewFlagSet("test", 0)
-	test := []string{"blah", "blah"}
-	set.Parse(test)
+		context := NewContext(app, set, nil)
 
-	c := NewContext(app, set, nil)
+		command := Command{
+			Name:        "test-cmd",
+			Aliases:     []string{"tc"},
+			Usage:       "this is for testing",
+			Description: "testing",
+			Action:      func(_ *Context) {},
+		}
 
-	command := Command{
-		Name:            "test-cmd",
-		Aliases:         []string{"tc"},
-		Usage:           "this is for testing",
-		Description:     "testing",
-		Action:          func(_ *Context) {},
-		SkipFlagParsing: true,
+		command.SkipFlagParsing = c.skipFlagParsing
+
+		err := command.Run(context)
+
+		expect(t, err, c.expectedErr)
+		expect(t, []string(context.Args()), c.testArgs)
 	}
-	err := command.Run(c)
-
-	expect(t, err, nil)
-}
-
-// Fix bug with ignoring flag parsing that would still parse the first flag
-func TestCommandIgnoreFlagsIncludingFirstArgument(t *testing.T) {
-	app := NewApp()
-	set := flag.NewFlagSet("test", 0)
-	test := []string{"blah", "-break"}
-	set.Parse(test)
-
-	c := NewContext(app, set, nil)
-
-	command := Command{
-		Name:            "test-cmd",
-		Aliases:         []string{"tc"},
-		Usage:           "this is for testing",
-		Description:     "testing",
-		Action:          func(_ *Context) {},
-		SkipFlagParsing: true,
-	}
-	err := command.Run(c)
-	expect(t, err, nil)
-
-	expect(t, []string(c.Args()), []string{"blah", "-break"})
 }


### PR DESCRIPTION
I cleaned up the separate tests into just one which uses a [test table](http://dave.cheney.net/2013/06/09/writing-table-driven-tests-in-go) (since I noticed there is a lot of duplication in them) and added a case for `--help` (another issue I had encountered that this patch fixes).

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>