### PR TITLE
test: avoid output from "go test" when tests pass

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -556,6 +557,7 @@ func TestAppNoHelpFlag(t *testing.T) {
 	HelpFlag = BoolFlag{}
 
 	app := NewApp()
+	app.Writer = ioutil.Discard
 	err := app.Run([]string{"test", "-h"})
 
 	if err != flag.ErrHelp {

--- a/command_test.go
+++ b/command_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"flag"
+	"io/ioutil"
 	"testing"
 )
 
@@ -20,6 +21,7 @@ func TestCommandFlagParsing(t *testing.T) {
 
 	for _, c := range cases {
 		app := NewApp()
+		app.Writer = ioutil.Discard
 		set := flag.NewFlagSet("test", 0)
 		set.Parse(c.testArgs)
 


### PR DESCRIPTION
Some tests where printing to os.Stdout as a side effect even if the
output was not used/checked in the test.