### PR TITLE
Run check completion before error checking

### DIFF
--- a/app.go
+++ b/app.go
@@ -126,15 +126,15 @@ func (a *App) Run(arguments []string) (err error) {
 	}
 	context := NewContext(a, set, nil)
 
+	if checkCompletions(context) {
+		return nil
+	}
+
 	if err != nil {
 		fmt.Fprintln(a.Writer, "Incorrect Usage.")
 		fmt.Fprintln(a.Writer)
 		ShowAppHelp(context)
 		return err
-	}
-
-	if checkCompletions(context) {
-		return nil
 	}
 
 	if !a.HideHelp && checkHelp(context) {
@@ -233,15 +233,15 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 		return nerr
 	}
 
+	if checkCompletions(context) {
+		return nil
+	}
+
 	if err != nil {
 		fmt.Fprintln(a.Writer, "Incorrect Usage.")
 		fmt.Fprintln(a.Writer)
 		ShowSubcommandHelp(context)
 		return err
-	}
-
-	if checkCompletions(context) {
-		return nil
 	}
 
 	if len(a.Commands) > 0 {


### PR DESCRIPTION
I was trying to implement bash completion for flags when I noticed that the CLI prints "Incorrect Usage." and the help when a flag is entered without a value.

This prevents from providing completion for flags when no character for the value has been entered yet.

Imagine you had a cli like: `somaApp -f <some local file> argument1 argument2`. If the user types `someApp -f` and invoke the bash completion, the cli should reach the completion methods before the error is raised. In this way it's possible for example to provide a list of local files for completion.

