### PR TITLE
Remove panic from help.

### DIFF
--- a/help.go
+++ b/help.go
@@ -180,7 +180,9 @@ func printHelp(out io.Writer, templ string, data interface{}) {
 	t := template.Must(template.New("help").Funcs(funcMap).Parse(templ))
 	err := t.Execute(w, data)
 	if err != nil {
-		panic(err)
+		// If the writer is closed, t.Execute will fail, and there's nothing
+		// we can do to recover. We could send this to os.Stderr if we need.
+		return
 	}
 	w.Flush()
 }


### PR DESCRIPTION
There is a panic in printHelp that can be trivially triggered when the
shell closes os.Stdout. This happens, for example, when data is piped
between a cli app and something else.

See https://github.com/helm/helm/issues/387