### PR TITLE
Added ci configuration for windows using AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+install:
+  - go version
+  - go env
+
+build_script:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - go vet ./...
+  - go test -v ./...
+
+test: off
+
+deploy: off


### PR DESCRIPTION
Regarding your comment from #321 I've created a build configuration (and tested it at my development branch windows-ci). You can see the running result at https://ci.appveyor.com/project/blaubaer/gocli/build/5

If merged to the master branch only a sigin to https://ci.appveyor.com/ and a linking to your project is required to bring this to work.