### PR TITLE
Add NArg method to context

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ app.Flags = []cli.Flag {
 }
 app.Action = func(c *cli.Context) {
   name := "someone"
-  if len(c.Args()) > 0 {
+  if c.NArg() > 0 {
     name = c.Args()[0]
   }
   if c.String("lang") == "spanish" {
@@ -180,7 +180,7 @@ app.Flags = []cli.Flag {
 }
 app.Action = func(c *cli.Context) {
   name := "someone"
-  if len(c.Args()) > 0 {
+  if c.NArg() > 0 {
     name = c.Args()[0]
   }
   if language == "spanish" {
@@ -308,7 +308,7 @@ app.Commands = []cli.Command{
     },
     BashComplete: func(c *cli.Context) {
       // This will complete if no args are passed
-      if len(c.Args()) > 0 {
+      if c.NArg() > 0 {
         return
       }
       for _, t := range tasks {

--- a/context.go
+++ b/context.go
@@ -197,6 +197,11 @@ func (c *Context) Args() Args {
 	return args
 }
 
+// Returns the number of the command line arguments.
+func (c *Context) NArg() int {
+	return len(c.Args())
+}
+
 // Returns the nth argument, or else a blank string
 func (a Args) Get(n int) string {
 	if len(a) > n {

--- a/context_test.go
+++ b/context_test.go
@@ -64,6 +64,14 @@ func TestContext_Args(t *testing.T) {
 	expect(t, c.Bool("myflag"), true)
 }
 
+func TestContext_NArg(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("myflag", false, "doc")
+	c := NewContext(nil, set, nil)
+	set.Parse([]string{"--myflag", "bat", "baz"})
+	expect(t, c.NArg(), 2)
+}
+
 func TestContext_IsSet(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool("myflag", false, "doc")


### PR DESCRIPTION
This PR adds ```NArg``` method to ```Context``` struct.

IMHO, it would be better to use ```c.NArg()``` just like built-in [flag.NArg](https://golang.org/pkg/flag/#NArg)