### PR TITLE
Never show version if HideVersion=true

### DIFF
--- a/app.go
+++ b/app.go
@@ -32,7 +32,7 @@ type App struct {
 	EnableBashCompletion bool
 	// Boolean to hide built-in help command
 	HideHelp bool
-	// Boolean to hide built-in version flag
+	// Boolean to hide built-in version flag and the VERSION section of help
 	HideVersion bool
 	// An action to execute when the bash-completion flag is set
 	BashComplete func(context *Context)

--- a/help.go
+++ b/help.go
@@ -16,10 +16,10 @@ var AppHelpTemplate = `NAME:
 
 USAGE:
    {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .Flags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}
-   {{if .Version}}
+   {{if .Version}}{{if not .HideVersion}}
 VERSION:
    {{.Version}}
-   {{end}}{{if len .Authors}}
+   {{end}}{{end}}{{if len .Authors}}
 AUTHOR(S):
    {{range .Authors}}{{ . }}{{end}}
    {{end}}{{if .Commands}}

--- a/help_test.go
+++ b/help_test.go
@@ -35,6 +35,22 @@ func Test_ShowAppHelp_NoVersion(t *testing.T) {
 	}
 }
 
+func Test_ShowAppHelp_HideVersion(t *testing.T) {
+	output := new(bytes.Buffer)
+	app := NewApp()
+	app.Writer = output
+
+	app.HideVersion = true
+
+	c := NewContext(app, nil, nil)
+
+	ShowAppHelp(c)
+
+	if bytes.Index(output.Bytes(), []byte("VERSION:")) != -1 {
+		t.Errorf("expected\n%snot to include %s", output.String(), "VERSION:")
+	}
+}
+
 func Test_Help_Custom_Flags(t *testing.T) {
 	oldFlag := HelpFlag
 	defer func() {


### PR DESCRIPTION
Because the default version is `0.0.0`, it is actually impossible to hide the version just by setting `HideVersion` to `true`.

This PR is fixing it.