### PR TITLE
Add option to make categories with command, to display a more structured help

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,45 @@ app.Commands = []cli.Command{
 ...
 ```
 
+### Subcommands categories
+
+For additional organization in apps that have many subcommands, you can
+associate a category for each command to group them together in the help
+output.
+
+E.g.
+
+```go
+...
+	app.Commands = []cli.Command{
+		{
+			Name: "noop",
+		},
+		{
+			Name:     "add",
+			Category: "template",
+		},
+		{
+			Name:     "remove",
+			Category: "template",
+		},
+	}
+...
+```
+
+Will include:
+
+```
+...
+COMMANDS:
+    noop
+
+  Template actions:
+    add
+    remove
+...
+```
+
 ### Bash Completion
 
 You can enable completion commands by setting the `EnableBashCompletion`

--- a/app.go
+++ b/app.go
@@ -37,8 +37,8 @@ type App struct {
 	HideVersion bool
 	// Display commands by category
 	CategorizedHelp bool
-	// Populate when displaying AppHelp
-	Categories CommandCategories
+	// Populate on app startup, only gettable throught method Categories()
+	categories CommandCategories
 	// An action to execute when the bash-completion flag is set
 	BashComplete func(context *Context)
 	// An action to execute before any subcommands are run, but after the context is ready
@@ -101,12 +101,12 @@ func (a *App) Run(arguments []string) (err error) {
 	}
 
 	if a.CategorizedHelp {
-		a.Categories = CommandCategories{}
+		a.categories = CommandCategories{}
 		for _, command := range a.Commands {
-			a.Categories = a.Categories.AddCommand(command.Category, command)
+			a.categories = a.categories.AddCommand(command.Category, command)
 		}
 	}
-	sort.Sort(a.Categories)
+	sort.Sort(a.categories)
 
 	newCmds := []Command{}
 	for _, c := range a.Commands {
@@ -327,6 +327,11 @@ func (a *App) Command(name string) *Command {
 	}
 
 	return nil
+}
+
+// Returnes the array containing all the categories with the commands they contain
+func (a *App) Categories() CommandCategories {
+	return a.categories
 }
 
 func (a *App) hasFlag(flag Flag) bool {

--- a/app.go
+++ b/app.go
@@ -35,8 +35,6 @@ type App struct {
 	HideHelp bool
 	// Boolean to hide built-in version flag
 	HideVersion bool
-	// Display commands by category
-	CategorizedHelp bool
 	// Populate on app startup, only gettable throught method Categories()
 	categories CommandCategories
 	// An action to execute when the bash-completion flag is set
@@ -100,14 +98,6 @@ func (a *App) Run(arguments []string) (err error) {
 		a.Authors = append(a.Authors, Author{Name: a.Author, Email: a.Email})
 	}
 
-	if a.CategorizedHelp {
-		a.categories = CommandCategories{}
-		for _, command := range a.Commands {
-			a.categories = a.categories.AddCommand(command.Category, command)
-		}
-	}
-	sort.Sort(a.categories)
-
 	newCmds := []Command{}
 	for _, c := range a.Commands {
 		if c.HelpName == "" {
@@ -116,6 +106,12 @@ func (a *App) Run(arguments []string) (err error) {
 		newCmds = append(newCmds, c)
 	}
 	a.Commands = newCmds
+
+	a.categories = CommandCategories{}
+	for _, command := range a.Commands {
+		a.categories = a.categories.AddCommand(command.Category, command)
+	}
+	sort.Sort(a.categories)
 
 	// append help to commands
 	if a.Command(helpCommand.Name) == nil && !a.HideHelp {

--- a/app.go
+++ b/app.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"sort"
 	"time"
 )
 
@@ -37,7 +38,7 @@ type App struct {
 	// Display commands by category
 	CategorizedHelp bool
 	// Populate when displaying AppHelp
-	Categories map[string]Commands
+	Categories CommandCategories
 	// An action to execute when the bash-completion flag is set
 	BashComplete func(context *Context)
 	// An action to execute before any subcommands are run, but after the context is ready
@@ -100,11 +101,12 @@ func (a *App) Run(arguments []string) (err error) {
 	}
 
 	if a.CategorizedHelp {
-		a.Categories = make(map[string]Commands)
+		a.Categories = CommandCategories{}
 		for _, command := range a.Commands {
-			a.Categories[command.Category] = append(a.Categories[command.Category], command)
+			a.Categories = a.Categories.AddCommand(command.Category, command)
 		}
 	}
+	sort.Sort(a.Categories)
 
 	newCmds := []Command{}
 	for _, c := range a.Commands {

--- a/app.go
+++ b/app.go
@@ -34,6 +34,10 @@ type App struct {
 	HideHelp bool
 	// Boolean to hide built-in version flag
 	HideVersion bool
+	// Display commands by category
+	CategorizedHelp bool
+	// Populate when displaying AppHelp
+	Categories map[string]Commands
 	// An action to execute when the bash-completion flag is set
 	BashComplete func(context *Context)
 	// An action to execute before any subcommands are run, but after the context is ready
@@ -93,6 +97,13 @@ func NewApp() *App {
 func (a *App) Run(arguments []string) (err error) {
 	if a.Author != "" || a.Email != "" {
 		a.Authors = append(a.Authors, Author{Name: a.Author, Email: a.Email})
+	}
+
+	if a.CategorizedHelp {
+		a.Categories = make(map[string]Commands)
+		for _, command := range a.Commands {
+			a.Categories[command.Category] = append(a.Categories[command.Category], command)
+		}
 	}
 
 	newCmds := []Command{}

--- a/app_test.go
+++ b/app_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -936,6 +937,49 @@ func TestApp_Run_Version(t *testing.T) {
 		if !strings.Contains(output, "0.1.0") {
 			t.Errorf("want version to contain %q, did not: \n%q", "0.1.0", output)
 		}
+	}
+}
+
+func TestApp_Run_Categories(t *testing.T) {
+	app := NewApp()
+	app.Name = "categories"
+	app.CategorizedHelp = true
+	app.Commands = []Command{
+		Command{
+			Name:     "command1",
+			Category: "1",
+		},
+		Command{
+			Name:     "command2",
+			Category: "1",
+		},
+		Command{
+			Name:     "command3",
+			Category: "2",
+		},
+	}
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+
+	app.Run([]string{"categories"})
+
+	expect := CommandCategories{
+		&CommandCategory{
+			Name: "1",
+			Commands: []Command{
+				app.Commands[0],
+				app.Commands[1],
+			},
+		},
+		&CommandCategory{
+			Name: "2",
+			Commands: []Command{
+				app.Commands[2],
+			},
+		},
+	}
+	if !reflect.DeepEqual(app.Categories(), expect) {
+		t.Fatalf("expected categories %#v, to equal %#v", app.Categories(), expect)
 	}
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -943,7 +943,6 @@ func TestApp_Run_Version(t *testing.T) {
 func TestApp_Run_Categories(t *testing.T) {
 	app := NewApp()
 	app.Name = "categories"
-	app.CategorizedHelp = true
 	app.Commands = []Command{
 		Command{
 			Name:     "command1",
@@ -980,6 +979,13 @@ func TestApp_Run_Categories(t *testing.T) {
 	}
 	if !reflect.DeepEqual(app.Categories(), expect) {
 		t.Fatalf("expected categories %#v, to equal %#v", app.Categories(), expect)
+	}
+
+	output := buf.String()
+	t.Logf("output: %q\n", buf.Bytes())
+
+	if !strings.Contains(output, "1:\n    command1") {
+		t.Errorf("want buffer to include category %q, did not: \n%q", "1:\n    command1", output)
 	}
 }
 

--- a/category.go
+++ b/category.go
@@ -1,0 +1,30 @@
+package cli
+
+type CommandCategories []*CommandCategory
+
+type CommandCategory struct {
+	Name     string
+	Commands Commands
+}
+
+func (c CommandCategories) Less(i, j int) bool {
+	return c[i].Name < c[j].Name
+}
+
+func (c CommandCategories) Len() int {
+	return len(c)
+}
+
+func (c CommandCategories) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+func (c CommandCategories) AddCommand(category string, command Command) CommandCategories {
+	for _, commandCategory := range c {
+		if commandCategory.Name == category {
+			commandCategory.Commands = append(commandCategory.Commands, command)
+			return c
+		}
+	}
+	return append(c, &CommandCategory{Name: category, Commands: []Command{command}})
+}

--- a/command.go
+++ b/command.go
@@ -22,6 +22,8 @@ type Command struct {
 	Description string
 	// A short description of the arguments of this command
 	ArgsUsage string
+	// The category the command is part of
+	Category string
 	// The function to call when checking for bash command completions
 	BashComplete func(context *Context)
 	// An action to execute before any sub-subcommands are run, but after the context is ready
@@ -37,7 +39,7 @@ type Command struct {
 	// If this function is not set, the "Incorrect usage" is displayed and the execution is interrupted.
 	OnUsageError func(context *Context, err error) error
 	// List of child commands
-	Subcommands []Command
+	Subcommands Commands
 	// List of flags to parse
 	Flags []Flag
 	// Treat all flags as normal arguments if true
@@ -58,6 +60,8 @@ func (c Command) FullName() string {
 	}
 	return strings.Join(c.commandNamePath, " ")
 }
+
+type Commands []Command
 
 // Invokes the command given the context, parses ctx.Args() to generate command-specific flags
 func (c Command) Run(ctx *Context) (err error) {

--- a/command.go
+++ b/command.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strings"
 )
 
@@ -230,6 +231,13 @@ func (c Command) startApp(ctx *Context) error {
 	app.Author = ctx.App.Author
 	app.Email = ctx.App.Email
 	app.Writer = ctx.App.Writer
+
+	app.categories = CommandCategories{}
+	for _, command := range c.Subcommands {
+		app.categories = app.categories.AddCommand(command.Category, command)
+	}
+
+	sort.Sort(app.categories)
 
 	// bash completion
 	app.EnableBashCompletion = ctx.App.EnableBashCompletion

--- a/help.go
+++ b/help.go
@@ -23,9 +23,12 @@ VERSION:
 AUTHOR(S):
    {{range .Authors}}{{ . }}{{end}}
    {{end}}{{if .Commands}}
-COMMANDS:
-   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
-   {{end}}{{end}}{{if .Flags}}
+COMMANDS:{{if .CategorizedHelp}}{{range $category, $commands := .Categories}}{{if $category}}
+  {{$category}}{{ ":" }}{{end}}{{range $commands}}
+    {{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}{{end}}
+{{end}}{{else}}{{range .Commands}}
+   {{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}{{end}}
+{{end}}{{end}}{{if .Flags}}
 GLOBAL OPTIONS:
    {{range .Flags}}{{.}}
    {{end}}{{end}}{{if .Copyright }}
@@ -43,6 +46,9 @@ var CommandHelpTemplate = `NAME:
 USAGE:
    {{.HelpName}}{{if .Flags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{if .Description}}
 
+{{if .Category}}CATEGORY:
+   {{.Category}}
+{{end}}
 DESCRIPTION:
    {{.Description}}{{end}}{{if .Flags}}
 

--- a/help.go
+++ b/help.go
@@ -23,11 +23,9 @@ VERSION:
 AUTHOR(S):
    {{range .Authors}}{{ . }}{{end}}
    {{end}}{{if .Commands}}
-COMMANDS:{{if .CategorizedHelp}}{{range .Categories}}{{if .Name}}
+COMMANDS:{{range .Categories}}{{if .Name}}
   {{.Name}}{{ ":" }}{{end}}{{range .Commands}}
     {{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}{{end}}
-{{end}}{{else}}{{range .Commands}}
-   {{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}{{end}}
 {{end}}{{end}}{{if .Flags}}
 GLOBAL OPTIONS:
    {{range .Flags}}{{.}}
@@ -44,11 +42,12 @@ var CommandHelpTemplate = `NAME:
    {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{.HelpName}}{{if .Flags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{if .Description}}
+   {{.HelpName}}{{if .Flags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{if .Category}}
 
-{{if .Category}}CATEGORY:
-   {{.Category}}
-{{end}}DESCRIPTION:
+CATEGORY:
+   {{.Category}}{{end}}{{if .Description}}
+
+DESCRIPTION:
    {{.Description}}{{end}}{{if .Flags}}
 
 OPTIONS:
@@ -65,9 +64,10 @@ var SubcommandHelpTemplate = `NAME:
 USAGE:
    {{.HelpName}} command{{if .Flags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
 
-COMMANDS:
-   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
-   {{end}}{{if .Flags}}
+COMMANDS:{{range .Categories}}{{if .Name}}
+  {{.Name}}{{ ":" }}{{end}}{{range .Commands}}
+    {{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}{{end}}
+{{end}}{{if .Flags}}
 OPTIONS:
    {{range .Flags}}{{.}}
    {{end}}{{end}}

--- a/help.go
+++ b/help.go
@@ -48,8 +48,7 @@ USAGE:
 
 {{if .Category}}CATEGORY:
    {{.Category}}
-{{end}}
-DESCRIPTION:
+{{end}}DESCRIPTION:
    {{.Description}}{{end}}{{if .Flags}}
 
 OPTIONS:

--- a/help.go
+++ b/help.go
@@ -23,8 +23,8 @@ VERSION:
 AUTHOR(S):
    {{range .Authors}}{{ . }}{{end}}
    {{end}}{{if .Commands}}
-COMMANDS:{{if .CategorizedHelp}}{{range $category, $commands := .Categories}}{{if $category}}
-  {{$category}}{{ ":" }}{{end}}{{range $commands}}
+COMMANDS:{{if .CategorizedHelp}}{{range .Categories}}{{if .Name}}
+  {{.Name}}{{ ":" }}{{end}}{{range .Commands}}
     {{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}{{end}}
 {{end}}{{else}}{{range .Commands}}
    {{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}{{end}}


### PR DESCRIPTION
Extension of #159 to add categories to commands.

Changes from that PR:

* Subcommands can have categories now too
* Removed `CategorizedHelp` in lieu of just always categorizing (with the default category being `""`) so that you can have a mix of categorized and uncategorized subcommands.
* Added notes to README about usage