### PR TITLE
yaml file laoder has so as to expand the tilde

### DIFF
--- a/altsrc/yaml_file_loader.go
+++ b/altsrc/yaml_file_loader.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/codegangsta/cli"
 
+	"gopkg.in/mattes/go-expand-tilde.v1"
 	"gopkg.in/yaml.v2"
 )
 
@@ -74,6 +75,11 @@ func loadDataFrom(filePath string) ([]byte, error) {
 			return nil, fmt.Errorf("scheme of %s is unsupported", filePath)
 		}
 	} else if u.Path != "" { // i dont have a host, but I have a path. I am a local file.
+		if path, expandErr := tilde.Expand(filePath); expandErr == nil {
+			filePath = path
+		} else {
+			return nil, fmt.Errorf("Cannot read from file: '%s' because it failed to expand the file path.")
+		}
 		if _, notFoundFileErr := os.Stat(filePath); notFoundFileErr != nil {
 			return nil, fmt.Errorf("Cannot read from file: '%s' because it does not exist.", filePath)
 		}

--- a/altsrc/yaml_file_loader.go
+++ b/altsrc/yaml_file_loader.go
@@ -78,7 +78,7 @@ func loadDataFrom(filePath string) ([]byte, error) {
 		if path, expandErr := tilde.Expand(filePath); expandErr == nil {
 			filePath = path
 		} else {
-			return nil, fmt.Errorf("Cannot read from file: '%s' because it failed to expand the file path.")
+			return nil, fmt.Errorf("Cannot read from file: '%s' because it failed to expand the file path.", path)
 		}
 		if _, notFoundFileErr := os.Stat(filePath); notFoundFileErr != nil {
 			return nil, fmt.Errorf("Cannot read from file: '%s' because it does not exist.", filePath)


### PR DESCRIPTION
Currently, we only take in the Unix-like OS

__altsrc is not to expand the tilde__

From the path, which includes the tilde ( "~ / .mysrc") attempted to load a YAML file, but failed.
altsrc does not expand the tilde as "$HOME".

Use the https://github.com/mattes/go-expand-tilde, we want to improve this.
We prepare to commit to pull request.

However, because dependent external library increases, is worried.
If you are satisfied, please let the opinion of the committers.