### PR TITLE
use filepath.Base instead of path.Base in Name & HelpName as default.

### DIFF
--- a/app.go
+++ b/app.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"time"
 )
@@ -80,8 +80,8 @@ func compileTime() time.Time {
 // Creates a new cli Application with some reasonable defaults for Name, Usage, Version and Action.
 func NewApp() *App {
 	return &App{
-		Name:         path.Base(os.Args[0]),
-		HelpName:     path.Base(os.Args[0]),
+		Name:         filepath.Base(os.Args[0]),
+		HelpName:     filepath.Base(os.Args[0]),
 		Usage:        "A new cli application",
 		UsageText:    "",
 		Version:      "0.0.0",


### PR DESCRIPTION
path.Base does not support backslash on windows.