### PR TITLE
Overwrite slice flag defaults when set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 ### Added
 - Support for placeholders in flag usage strings
 
+## [2.0.0]
+### Added
+- `NewStringSlice` and `NewIntSlice` for creating their related types
+
+### Removed
+- the ability to specify `&StringSlice{...string}` or `&IntSlice{...int}`.
+To migrate to the new API, you may choose to run [this helper
+(python) script](./cli-migrate-slice-types).
+
 ## [1.14.0] - 2016-04-03 (backfilled 2016-04-25)
 ### Added
 - Codebeat badge
@@ -220,6 +229,7 @@
 - Initial implementation.
 
 [Unreleased]: https://github.com/codegangsta/cli/compare/v1.14.0...HEAD
+[2.0.0]: https://github.com/codegangsta/cli/compare/v1.14.0...v2.0.0
 [1.14.0]: https://github.com/codegangsta/cli/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/codegangsta/cli/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/codegangsta/cli/compare/v1.11.1...v1.12.0

--- a/altsrc/flag.go
+++ b/altsrc/flag.go
@@ -122,7 +122,7 @@ func (f *StringSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputS
 				return err
 			}
 			if value != nil {
-				var sliceValue cli.StringSlice = value
+				var sliceValue cli.StringSlice = *(cli.NewStringSlice(value...))
 				eachName(f.Name, func(name string) {
 					underlyingFlag := f.set.Lookup(f.Name)
 					if underlyingFlag != nil {
@@ -163,7 +163,7 @@ func (f *IntSliceFlag) ApplyInputSourceValue(context *cli.Context, isc InputSour
 				return err
 			}
 			if value != nil {
-				var sliceValue cli.IntSlice = value
+				var sliceValue cli.IntSlice = *(cli.NewIntSlice(value...))
 				eachName(f.Name, func(name string) {
 					underlyingFlag := f.set.Lookup(f.Name)
 					if underlyingFlag != nil {

--- a/app_test.go
+++ b/app_test.go
@@ -313,8 +313,8 @@ func TestApp_ParseSliceFlags(t *testing.T) {
 	command := Command{
 		Name: "cmd",
 		Flags: []Flag{
-			IntSliceFlag{Name: "p", Value: &IntSlice{}, Usage: "set one or more ip addr"},
-			StringSliceFlag{Name: "ip", Value: &StringSlice{}, Usage: "set one or more ports to open"},
+			IntSliceFlag{Name: "p", Value: NewIntSlice(), Usage: "set one or more ip addr"},
+			StringSliceFlag{Name: "ip", Value: NewStringSlice(), Usage: "set one or more ports to open"},
 		},
 		Action: func(c *Context) {
 			parsedIntSlice = c.IntSlice("p")

--- a/cli-migrate-slice-types
+++ b/cli-migrate-slice-types
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+from __future__ import print_function, unicode_literals
+
+import argparse
+import os
+import re
+import sys
+
+
+DESCRIPTION = """\
+Migrate arbitrary `.go` sources from the pre-v2.0.0 API for StringSlice and
+IntSlice types, optionally writing the changes back to file.
+"""
+SLICE_TYPE_RE = re.compile(
+    '&cli\\.(?P<type>IntSlice|StringSlice){(?P<args>[^}]*)}',
+    flags=re.DOTALL
+)
+
+
+def main(sysargs=sys.argv[:]):
+    parser = argparse.ArgumentParser(
+        description=DESCRIPTION,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('basedir', nargs='?', metavar='BASEDIR',
+        type=os.path.abspath, default=os.getcwd())
+    parser.add_argument('-w', '--write', help='write changes back to file',
+        action='store_true', default=False)
+
+    args = parser.parse_args(sysargs[1:])
+
+    for filepath in _find_candidate_files(args.basedir):
+        updated_source = _update_source(filepath)
+        if args.write:
+            print('Updating {!r}'.format(filepath))
+
+            with open(filepath, 'w') as outfile:
+                outfile.write(updated_source)
+        else:
+            print('// -> Updated {!r}'.format(filepath))
+            print(updated_source)
+
+    return 0
+
+
+def _update_source(filepath):
+    with open(filepath) as infile:
+        source = infile.read()
+        return SLICE_TYPE_RE.sub(_slice_type_repl, source)
+
+
+def _slice_type_repl(match):
+    return 'cli.New{}({})'.format(
+        match.groupdict()['type'], match.groupdict()['args']
+    )
+
+
+def _find_candidate_files(basedir):
+    for curdir, dirs, files in os.walk(basedir):
+        for i, dirname in enumerate(dirs[:]):
+            if dirname.startswith('.'):
+                dirs.pop(i)
+
+        for filename in files:
+            if not filename.endswith('.go'):
+                continue
+
+            filepath = os.path.join(curdir, filename)
+            if not os.access(filepath, os.R_OK | os.W_OK):
+                continue
+
+            yield filepath
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/context.go
+++ b/context.go
@@ -362,7 +362,8 @@ func lookupBoolT(name string, set *flag.FlagSet) bool {
 
 func copyFlag(name string, ff *flag.Flag, set *flag.FlagSet) {
 	switch ff.Value.(type) {
-	case *StringSlice:
+	case Serializeder:
+		set.Set(name, ff.Value.(Serializeder).Serialized())
 	default:
 		set.Set(name, ff.Value.String())
 	}

--- a/flag.go
+++ b/flag.go
@@ -111,26 +111,39 @@ func (f GenericFlag) GetName() string {
 	return f.Name
 }
 
-// StringSlice is an opaque type for []string to satisfy flag.Value
-type StringSlice []string
+// StringSlice wraps a []string to satisfy flag.Value
+type StringSlice struct {
+	slice      []string
+	hasBeenSet bool
+}
+
+// NewStringSlice creates a *StringSlice with default values
+func NewStringSlice(defaults ...string) *StringSlice {
+	return &StringSlice{slice: append([]string{}, defaults...)}
+}
 
 // Set appends the string value to the list of values
 func (f *StringSlice) Set(value string) error {
-	*f = append(*f, value)
+	if !f.hasBeenSet {
+		f.slice = []string{}
+		f.hasBeenSet = true
+	}
+
+	f.slice = append(f.slice, value)
 	return nil
 }
 
 // String returns a readable representation of this value (for usage defaults)
 func (f *StringSlice) String() string {
-	return fmt.Sprintf("%s", *f)
+	return fmt.Sprintf("%s", f.slice)
 }
 
 // Value returns the slice of strings set by this flag
 func (f *StringSlice) Value() []string {
-	return *f
+	return f.slice
 }
 
-// StringSlice is a string flag that can be specified multiple times on the
+// StringSliceFlag is a string flag that can be specified multiple times on the
 // command-line
 type StringSliceFlag struct {
 	Name   string
@@ -163,10 +176,11 @@ func (f StringSliceFlag) Apply(set *flag.FlagSet) {
 		}
 	}
 
+	if f.Value == nil {
+		f.Value = &StringSlice{}
+	}
+
 	eachName(f.Name, func(name string) {
-		if f.Value == nil {
-			f.Value = &StringSlice{}
-		}
 		set.Var(f.Value, name, f.Usage)
 	})
 }
@@ -175,28 +189,51 @@ func (f StringSliceFlag) GetName() string {
 	return f.Name
 }
 
-// StringSlice is an opaque type for []int to satisfy flag.Value
-type IntSlice []int
+// IntSlice wraps an []int to satisfy flag.Value
+type IntSlice struct {
+	slice      []int
+	hasBeenSet bool
+}
+
+// NewIntSlice makes an *IntSlice with default values
+func NewIntSlice(defaults ...int) *IntSlice {
+	return &IntSlice{slice: append([]int{}, defaults...)}
+}
+
+// SetInt directly adds an integer to the list of values
+func (i *IntSlice) SetInt(value int) {
+	if !i.hasBeenSet {
+		i.slice = []int{}
+		i.hasBeenSet = true
+	}
+
+	i.slice = append(i.slice, value)
+}
 
 // Set parses the value into an integer and appends it to the list of values
-func (f *IntSlice) Set(value string) error {
+func (i *IntSlice) Set(value string) error {
+	if !i.hasBeenSet {
+		i.slice = []int{}
+		i.hasBeenSet = true
+	}
+
 	tmp, err := strconv.Atoi(value)
 	if err != nil {
 		return err
 	} else {
-		*f = append(*f, tmp)
+		i.slice = append(i.slice, tmp)
 	}
 	return nil
 }
 
 // String returns a readable representation of this value (for usage defaults)
-func (f *IntSlice) String() string {
-	return fmt.Sprintf("%d", *f)
+func (i *IntSlice) String() string {
+	return fmt.Sprintf("%v", i.slice)
 }
 
 // Value returns the slice of ints set by this flag
-func (f *IntSlice) Value() []int {
-	return *f
+func (i *IntSlice) Value() []int {
+	return i.slice
 }
 
 // IntSliceFlag is an int flag that can be specified multiple times on the

--- a/flag.go
+++ b/flag.go
@@ -165,7 +165,7 @@ func (f StringSliceFlag) Apply(set *flag.FlagSet) {
 		for _, envVar := range strings.Split(f.EnvVar, ",") {
 			envVar = strings.TrimSpace(envVar)
 			if envVal := os.Getenv(envVar); envVal != "" {
-				newVal := &StringSlice{}
+				newVal := NewStringSlice()
 				for _, s := range strings.Split(envVal, ",") {
 					s = strings.TrimSpace(s)
 					newVal.Set(s)
@@ -177,7 +177,7 @@ func (f StringSliceFlag) Apply(set *flag.FlagSet) {
 	}
 
 	if f.Value == nil {
-		f.Value = &StringSlice{}
+		f.Value = NewStringSlice()
 	}
 
 	eachName(f.Name, func(name string) {
@@ -272,10 +272,11 @@ func (f IntSliceFlag) Apply(set *flag.FlagSet) {
 		}
 	}
 
+	if f.Value == nil {
+		f.Value = NewIntSlice()
+	}
+
 	eachName(f.Name, func(name string) {
-		if f.Value == nil {
-			f.Value = &IntSlice{}
-		}
 		set.Var(f.Value, name, f.Usage)
 	})
 }

--- a/flag.go
+++ b/flag.go
@@ -141,9 +141,9 @@ func (f *StringSlice) Set(value string) error {
 	}
 
 	if strings.HasPrefix(value, slPfx) {
-		v := []string{}
-		_ = json.Unmarshal([]byte(strings.Replace(value, slPfx, "", 1)), v)
-		f.slice = append(f.slice, v...)
+		// Deserializing assumes overwrite
+		_ = json.Unmarshal([]byte(strings.Replace(value, slPfx, "", 1)), &f.slice)
+		f.hasBeenSet = true
 		return nil
 	}
 
@@ -242,10 +242,10 @@ func (i *IntSlice) Set(value string) error {
 		i.hasBeenSet = true
 	}
 
-	if strings.HasPrefix(slPfx, value) {
-		v := []int{}
-		_ = json.Unmarshal([]byte(strings.Replace(value, slPfx, "", 1)), v)
-		i.slice = append(i.slice, v...)
+	if strings.HasPrefix(value, slPfx) {
+		// Deserializing assumes overwrite
+		_ = json.Unmarshal([]byte(strings.Replace(value, slPfx, "", 1)), &i.slice)
+		i.hasBeenSet = true
 		return nil
 	}
 
@@ -261,6 +261,12 @@ func (i *IntSlice) Set(value string) error {
 // String returns a readable representation of this value (for usage defaults)
 func (i *IntSlice) String() string {
 	return fmt.Sprintf("%v", i.slice)
+}
+
+// Serialized allows IntSlice to fulfill Serializeder
+func (i *IntSlice) Serialized() string {
+	jsonBytes, _ := json.Marshal(i.slice)
+	return fmt.Sprintf("%s%s", slPfx, string(jsonBytes))
 }
 
 // Value returns the slice of ints set by this flag

--- a/flag.go
+++ b/flag.go
@@ -258,7 +258,7 @@ func (f IntSliceFlag) Apply(set *flag.FlagSet) {
 		for _, envVar := range strings.Split(f.EnvVar, ",") {
 			envVar = strings.TrimSpace(envVar)
 			if envVal := os.Getenv(envVar); envVal != "" {
-				newVal := &IntSlice{}
+				newVal := NewIntSlice()
 				for _, s := range strings.Split(envVal, ",") {
 					s = strings.TrimSpace(s)
 					err := newVal.Set(s)

--- a/flag_test.go
+++ b/flag_test.go
@@ -43,7 +43,6 @@ var stringFlagTests = []struct {
 }
 
 func TestStringFlagHelpOutput(t *testing.T) {
-
 	for _, test := range stringFlagTests {
 		flag := StringFlag{Name: test.name, Usage: test.usage, Value: test.value}
 		output := flag.String()
@@ -376,11 +375,12 @@ func TestParseMultiStringSlice(t *testing.T) {
 			StringSliceFlag{Name: "serve, s", Value: NewStringSlice()},
 		},
 		Action: func(ctx *Context) {
-			if !reflect.DeepEqual(ctx.StringSlice("serve"), []string{"10", "20"}) {
-				t.Errorf("main name not set")
+			expected := []string{"10", "20"}
+			if !reflect.DeepEqual(ctx.StringSlice("serve"), expected) {
+				t.Errorf("main name not set: %v != %v", expected, ctx.StringSlice("serve"))
 			}
-			if !reflect.DeepEqual(ctx.StringSlice("s"), []string{"10", "20"}) {
-				t.Errorf("short name not set")
+			if !reflect.DeepEqual(ctx.StringSlice("s"), expected) {
+				t.Errorf("short name not set: %v != %v", expected, ctx.StringSlice("s"))
 			}
 		},
 	}).Run([]string{"run", "-s", "10", "-s", "20"})
@@ -392,11 +392,12 @@ func TestParseMultiStringSliceWithDefaults(t *testing.T) {
 			StringSliceFlag{Name: "serve, s", Value: NewStringSlice("9", "2")},
 		},
 		Action: func(ctx *Context) {
-			if !reflect.DeepEqual(ctx.StringSlice("serve"), []string{"10", "20"}) {
-				t.Errorf("main name not set: %v", ctx.StringSlice("serve"))
+			expected := []string{"10", "20"}
+			if !reflect.DeepEqual(ctx.StringSlice("serve"), expected) {
+				t.Errorf("main name not set: %v != %v", expected, ctx.StringSlice("serve"))
 			}
-			if !reflect.DeepEqual(ctx.StringSlice("s"), []string{"10", "20"}) {
-				t.Errorf("short name not set: %v", ctx.StringSlice("s"))
+			if !reflect.DeepEqual(ctx.StringSlice("s"), expected) {
+				t.Errorf("short name not set: %v != %v", expected, ctx.StringSlice("s"))
 			}
 		},
 	}).Run([]string{"run", "-s", "10", "-s", "20"})
@@ -959,4 +960,36 @@ func TestParseGenericFromEnvCascade(t *testing.T) {
 		},
 	}
 	a.Run([]string{"run"})
+}
+
+func TestStringSlice_Serialized_Set(t *testing.T) {
+	sl0 := NewStringSlice("a", "b")
+	ser0 := sl0.Serialized()
+
+	if len(ser0) < len(slPfx) {
+		t.Fatalf("serialized shorter than expected: %q", ser0)
+	}
+
+	sl1 := NewStringSlice("c", "d")
+	sl1.Set(ser0)
+
+	if sl0.String() != sl1.String() {
+		t.Fatalf("pre and post serialization do not match: %v != %v", sl0, sl1)
+	}
+}
+
+func TestIntSlice_Serialized_Set(t *testing.T) {
+	sl0 := NewIntSlice(1, 2)
+	ser0 := sl0.Serialized()
+
+	if len(ser0) < len(slPfx) {
+		t.Fatalf("serialized shorter than expected: %q", ser0)
+	}
+
+	sl1 := NewIntSlice(3, 4)
+	sl1.Set(ser0)
+
+	if sl0.String() != sl1.String() {
+		t.Fatalf("pre and post serialization do not match: %v != %v", sl0, sl1)
+	}
 }

--- a/flag_test.go
+++ b/flag_test.go
@@ -188,9 +188,9 @@ var intSliceFlagTests = []struct {
 	value    *IntSlice
 	expected string
 }{
-	{"help", &IntSlice{}, "--help [--help option --help option]\t"},
-	{"h", &IntSlice{}, "-h [-h option -h option]\t"},
-	{"h", &IntSlice{}, "-h [-h option -h option]\t"},
+	{"help", NewIntSlice(), "--help [--help option --help option]\t"},
+	{"h", NewIntSlice(), "-h [-h option -h option]\t"},
+	{"h", NewIntSlice(), "-h [-h option -h option]\t"},
 	{"test", NewIntSlice(9), "--test [--test option --test option]\t"},
 }
 
@@ -371,7 +371,7 @@ func TestParseMultiStringFromEnvCascade(t *testing.T) {
 func TestParseMultiStringSlice(t *testing.T) {
 	(&App{
 		Flags: []Flag{
-			StringSliceFlag{Name: "serve, s", Value: &StringSlice{}},
+			StringSliceFlag{Name: "serve, s", Value: NewStringSlice()},
 		},
 		Action: func(ctx *Context) {
 			if !reflect.DeepEqual(ctx.StringSlice("serve"), []string{"10", "20"}) {
@@ -422,7 +422,7 @@ func TestParseMultiStringSliceFromEnv(t *testing.T) {
 
 	(&App{
 		Flags: []Flag{
-			StringSliceFlag{Name: "intervals, i", Value: &StringSlice{}, EnvVar: "APP_INTERVALS"},
+			StringSliceFlag{Name: "intervals, i", Value: NewStringSlice(), EnvVar: "APP_INTERVALS"},
 		},
 		Action: func(ctx *Context) {
 			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
@@ -460,7 +460,7 @@ func TestParseMultiStringSliceFromEnvCascade(t *testing.T) {
 
 	(&App{
 		Flags: []Flag{
-			StringSliceFlag{Name: "intervals, i", Value: &StringSlice{}, EnvVar: "COMPAT_INTERVALS,APP_INTERVALS"},
+			StringSliceFlag{Name: "intervals, i", Value: NewStringSlice(), EnvVar: "COMPAT_INTERVALS,APP_INTERVALS"},
 		},
 		Action: func(ctx *Context) {
 			if !reflect.DeepEqual(ctx.StringSlice("intervals"), []string{"20", "30", "40"}) {
@@ -568,7 +568,7 @@ func TestParseMultiIntFromEnvCascade(t *testing.T) {
 func TestParseMultiIntSlice(t *testing.T) {
 	(&App{
 		Flags: []Flag{
-			IntSliceFlag{Name: "serve, s", Value: &IntSlice{}},
+			IntSliceFlag{Name: "serve, s", Value: NewIntSlice()},
 		},
 		Action: func(ctx *Context) {
 			if !reflect.DeepEqual(ctx.IntSlice("serve"), []int{10, 20}) {
@@ -619,7 +619,7 @@ func TestParseMultiIntSliceFromEnv(t *testing.T) {
 
 	(&App{
 		Flags: []Flag{
-			IntSliceFlag{Name: "intervals, i", Value: &IntSlice{}, EnvVar: "APP_INTERVALS"},
+			IntSliceFlag{Name: "intervals, i", Value: NewIntSlice(), EnvVar: "APP_INTERVALS"},
 		},
 		Action: func(ctx *Context) {
 			if !reflect.DeepEqual(ctx.IntSlice("intervals"), []int{20, 30, 40}) {
@@ -657,7 +657,7 @@ func TestParseMultiIntSliceFromEnvCascade(t *testing.T) {
 
 	(&App{
 		Flags: []Flag{
-			IntSliceFlag{Name: "intervals, i", Value: &IntSlice{}, EnvVar: "COMPAT_INTERVALS,APP_INTERVALS"},
+			IntSliceFlag{Name: "intervals, i", Value: NewIntSlice(), EnvVar: "COMPAT_INTERVALS,APP_INTERVALS"},
 		},
 		Action: func(ctx *Context) {
 			if !reflect.DeepEqual(ctx.IntSlice("intervals"), []int{20, 30, 40}) {


### PR DESCRIPTION
Closes #160 
Closes #319 
Closes #314 
Closes #307 

*NOTE*: this includes an API change:

### old way, no longer valid:

``` go
s := &StringSlice{"foo", "bar"}
i := &IntSlice{1, 2}
```

### new way:

``` go
s := NewStringSlice("foo", "bar")
i := NewIntSlice(1, 2)
```