### PR TITLE
Cleaning up the recently-introduced deprecations

### DIFF
--- a/app.go
+++ b/app.go
@@ -12,7 +12,9 @@ import (
 )
 
 var (
-	appActionDeprecationURL = "https://github.com/codegangsta/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature"
+	changeLogURL                    = "https://github.com/codegangsta/cli/blob/master/CHANGELOG.md"
+	appActionDeprecationURL         = fmt.Sprintf("%s#deprecated-cli-app-action-signature", changeLogURL)
+	runAndExitOnErrorDeprecationURL = fmt.Sprintf("%s#deprecated-cli-app-runandexitonerror", changeLogURL)
 
 	contactSysadmin = "This is an error in the application.  Please contact the distributor of this application if this is not you."
 
@@ -230,9 +232,9 @@ func (a *App) Run(arguments []string) (err error) {
 
 // DEPRECATED: Another entry point to the cli app, takes care of passing arguments and error handling
 func (a *App) RunAndExitOnError() {
-	fmt.Fprintln(os.Stderr,
-		"DEPRECATED cli.App.RunAndExitOnError.  "+
-			"See https://github.com/codegangsta/cli/blob/master/CHANGELOG.md#deprecated-cli-app-runandexitonerror")
+	fmt.Fprintf(os.Stderr,
+		"DEPRECATED cli.App.RunAndExitOnError.  %s  See %s\n",
+		contactSysadmin, runAndExitOnErrorDeprecationURL)
 	if err := a.Run(os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -421,8 +423,9 @@ func HandleAction(action interface{}, context *Context) (err error) {
 	vals := reflect.ValueOf(action).Call([]reflect.Value{reflect.ValueOf(context)})
 
 	if len(vals) == 0 {
-		fmt.Fprintln(os.Stderr,
-			"DEPRECATED Action signature.  Must be `cli.ActionFunc`")
+		fmt.Fprintf(os.Stderr,
+			"DEPRECATED Action signature.  Must be `cli.ActionFunc`.  %s  See %s\n",
+			contactSysadmin, appActionDeprecationURL)
 		return nil
 	}
 


### PR DESCRIPTION
to ensure the intent, responsibility, and migration path are all more clear.