### PR TITLE
	Assert type against actual return val's interface.

### DIFF
--- a/app.go
+++ b/app.go
@@ -438,7 +438,7 @@ func HandleAction(action interface{}, context *Context) (err error) {
 		return errInvalidActionSignature
 	}
 
-	if retErr, ok := reflect.ValueOf(vals[0]).Interface().(error); ok {
+	if retErr, ok := vals[0].Interface().(error); ok {
 		return retErr
 	}
 


### PR DESCRIPTION
	Exit code example produces now correctly,
	https://github.com/codegangsta/cli#exit-code

	```
	$ ./ec --ginger-crouton=false
	it is not in the soup
	$ echo $?
	86
	$
	```