### PR TITLE
Include directories in shell completion

### DIFF
--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -1,14 +1,27 @@
-#! /bin/bash
+#!/bin/bash
 
 : ${PROG:=$(basename ${BASH_SOURCE})}
 
 _cli_bash_autocomplete() {
-     local cur opts base
-     COMPREPLY=()
-     cur="${COMP_WORDS[COMP_CWORD]}"
-     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
-     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-     return 0
- }
-  
- complete -F _cli_bash_autocomplete $PROG
+    local cur opts base replylen
+
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    if [ -n "${cur}" ] ; then
+      COMPREPLY=( $(compgen -S / -d -- ${cur}) )
+    else
+      COMPREPLY=()
+    fi
+
+    replylen=${#COMPREPLY}
+    opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "${opts}" -- ${cur}) )
+
+    if [ ${#COMPREPLY} -eq ${replylen} ] ; then
+      compopt -o nospace
+    fi
+
+    return 0
+}
+
+complete -F _cli_bash_autocomplete $PROG


### PR DESCRIPTION
Closes #388

### wait for it 🐉 
- [ ] port to `./autocomplete/zsh_autocomplete`
- [ ] add some tests
- [ ] does it blend?

### example
Here's some real interaction with an example app:

``` go
package main

import (
        "fmt"
        "os"

        "github.com/codegangsta/cli"
)

func main() {
        app := cli.NewApp()
        app.EnableBashCompletion = true

        app.Commands = []cli.Command{
                cli.Command{
                        Name: "wheespurr",
                        Action: func(ctx *cli.Context) error {
                                fmt.Println("shhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh")
                                return nil
                        },
                },
                cli.Command{
                        Name: "do",
                        Flags: []cli.Flag{
                                cli.StringSliceFlag{
                                        Name:  "hats",
                                        Value: &cli.StringSlice{"top", "fruit"},
                                },
                        },
                        Subcommands: cli.Commands{
                                cli.Command{
                                        Name: "snore",
                                        Action: func(ctx *cli.Context) error {
                                                fmt.Println("snxxxxxxxx")
                                                return nil
                                        },
                                },
                        },
                        Action: func(ctx *cli.Context) error {
                                defer func() {
                                        if r := recover(); r != nil {
                                                fmt.Printf("%s\n    -> %#v\n", r, r)
                                        }
                                }()
                                fmt.Printf("%#v\n", ctx.GlobalStringSlice("hats"))
                                return nil
                        },
                },
        }

        app.Run(os.Args)
}
```

I've compiled it to `./.t/example`, and here's a session with the `./autocomplete/bash_autocomplete` from this PR:

``` shell-session
failb0wl:.t me$ tree .
.
├── example
├── example.go
├── a
│   ├── b1
│   │   └── c
│   │       └── d
│   │           └── exclaim
│   ├── b2
│   ├── b3
│   └── b4
├── a.txt
└── b.txt
failb0wl:.t me$ PROG=example source ../autocomplete/bash_autocomplete ; export PATH="$PWD:$PATH"
failb0wl:.t me$ example <TAB>
do         h          help       wheespurr
failb0wl:.t me$ example a<TAB>/<TAB>
a/b1/  a/b2/  a/b3/  a/b4/
failb0wl:.t me$ example a/b1<TAB>/<TAB>c/<TAB>d/<TAB>
```