### PR TITLE
Provide a variable for writing output (the writer) with a default of os.Stderr

### DIFF
--- a/app.go
+++ b/app.go
@@ -228,11 +228,11 @@ func (a *App) Run(arguments []string) (err error) {
 
 // DEPRECATED: Another entry point to the cli app, takes care of passing arguments and error handling
 func (a *App) RunAndExitOnError() {
-	fmt.Fprintf(os.Stderr,
+	fmt.Fprintf(OutWriter,
 		"DEPRECATED cli.App.RunAndExitOnError.  %s  See %s\n",
 		contactSysadmin, runAndExitOnErrorDeprecationURL)
 	if err := a.Run(os.Args); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(OutWriter, err)
 		OsExiter(1)
 	}
 }
@@ -422,7 +422,7 @@ func HandleAction(action interface{}, context *Context) (err error) {
 	vals := reflect.ValueOf(action).Call([]reflect.Value{reflect.ValueOf(context)})
 
 	if len(vals) == 0 {
-		fmt.Fprintf(os.Stderr,
+		fmt.Fprintf(OutWriter,
 			"DEPRECATED Action signature.  Must be `cli.ActionFunc`.  %s  See %s\n",
 			contactSysadmin, appActionDeprecationURL)
 		return nil

--- a/app.go
+++ b/app.go
@@ -82,6 +82,8 @@ type App struct {
 	Email string
 	// Writer writer to write output to
 	Writer io.Writer
+	// ErrWriter writes error output
+	ErrWriter io.Writer
 	// Other custom info
 	Metadata map[string]interface{}
 }
@@ -228,11 +230,11 @@ func (a *App) Run(arguments []string) (err error) {
 
 // DEPRECATED: Another entry point to the cli app, takes care of passing arguments and error handling
 func (a *App) RunAndExitOnError() {
-	fmt.Fprintf(OutWriter,
+	fmt.Fprintf(a.errWriter(),
 		"DEPRECATED cli.App.RunAndExitOnError.  %s  See %s\n",
 		contactSysadmin, runAndExitOnErrorDeprecationURL)
 	if err := a.Run(os.Args); err != nil {
-		fmt.Fprintln(OutWriter, err)
+		fmt.Fprintln(a.errWriter(), err)
 		OsExiter(1)
 	}
 }
@@ -377,6 +379,16 @@ func (a *App) hasFlag(flag Flag) bool {
 	return false
 }
 
+func (a *App) errWriter() io.Writer {
+
+	// When the app ErrWriter is nil use the package level one.
+	if a.ErrWriter == nil {
+		return ErrWriter
+	}
+
+	return a.ErrWriter
+}
+
 func (a *App) appendFlag(flag Flag) {
 	if !a.hasFlag(flag) {
 		a.Flags = append(a.Flags, flag)
@@ -422,7 +434,7 @@ func HandleAction(action interface{}, context *Context) (err error) {
 	vals := reflect.ValueOf(action).Call([]reflect.Value{reflect.ValueOf(context)})
 
 	if len(vals) == 0 {
-		fmt.Fprintf(OutWriter,
+		fmt.Fprintf(ErrWriter,
 			"DEPRECATED Action signature.  Must be `cli.ActionFunc`.  %s  See %s\n",
 			contactSysadmin, appActionDeprecationURL)
 		return nil

--- a/errors.go
+++ b/errors.go
@@ -8,6 +8,10 @@ import (
 
 var OsExiter = os.Exit
 
+// OutWriter is used to write output to the user. This can be anything
+// implementing the io.Writer interface and defaults to os.Stderr.
+var OutWriter = os.Stderr
+
 type MultiError struct {
 	Errors []error
 }
@@ -69,7 +73,7 @@ func HandleExitCoder(err error) {
 
 	if exitErr, ok := err.(ExitCoder); ok {
 		if err.Error() != "" {
-			fmt.Fprintln(os.Stderr, err)
+			fmt.Fprintln(OutWriter, err)
 		}
 		OsExiter(exitErr.ExitCode())
 		return

--- a/errors.go
+++ b/errors.go
@@ -2,15 +2,16 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
 
 var OsExiter = os.Exit
 
-// OutWriter is used to write output to the user. This can be anything
+// ErrWriter is used to write errors to the user. This can be anything
 // implementing the io.Writer interface and defaults to os.Stderr.
-var OutWriter = os.Stderr
+var ErrWriter io.Writer = os.Stderr
 
 type MultiError struct {
 	Errors []error
@@ -73,7 +74,7 @@ func HandleExitCoder(err error) {
 
 	if exitErr, ok := err.(ExitCoder); ok {
 		if err.Error() != "" {
-			fmt.Fprintln(OutWriter, err)
+			fmt.Fprintln(ErrWriter, err)
 		}
 		OsExiter(exitErr.ExitCode())
 		return

--- a/flag.go
+++ b/flag.go
@@ -220,7 +220,7 @@ func (f IntSliceFlag) Apply(set *flag.FlagSet) {
 					s = strings.TrimSpace(s)
 					err := newVal.Set(s)
 					if err != nil {
-						fmt.Fprintf(OutWriter, err.Error())
+						fmt.Fprintf(ErrWriter, err.Error())
 					}
 				}
 				f.Value = newVal

--- a/flag.go
+++ b/flag.go
@@ -220,7 +220,7 @@ func (f IntSliceFlag) Apply(set *flag.FlagSet) {
 					s = strings.TrimSpace(s)
 					err := newVal.Set(s)
 					if err != nil {
-						fmt.Fprintf(os.Stderr, err.Error())
+						fmt.Fprintf(OutWriter, err.Error())
 					}
 				}
 				f.Value = newVal

--- a/help.go
+++ b/help.go
@@ -188,7 +188,7 @@ func printHelp(out io.Writer, templ string, data interface{}) {
 	err := t.Execute(w, data)
 	if err != nil {
 		// If the writer is closed, t.Execute will fail, and there's nothing
-		// we can do to recover. We could send this to os.Stderr if we need.
+		// we can do to recover. We could send this to OutWriter if we need.
 		return
 	}
 	w.Flush()

--- a/help.go
+++ b/help.go
@@ -188,7 +188,7 @@ func printHelp(out io.Writer, templ string, data interface{}) {
 	err := t.Execute(w, data)
 	if err != nil {
 		// If the writer is closed, t.Execute will fail, and there's nothing
-		// we can do to recover. We could send this to OutWriter if we need.
+		// we can do to recover. We could send this to ErrWriter if we need.
 		return
 	}
 	w.Flush()


### PR DESCRIPTION
This allows:

- Users to set their own writer (e.g., to wrap the text or send it elsewhere such as a log)
- Allows tests to capture the output and check responses.