### PR TITLE
Add a vet/test runner script with coverage on by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.coverprofile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+
 sudo: false
 
 go:
@@ -8,16 +9,14 @@ go:
 - 1.4
 - 1.5.4
 - 1.6.2
-- tip
+- master
 
 matrix:
   allow_failures:
-    - go: tip
+  - go: master
 
 before_script:
 - go get github.com/meatballhat/gfmxr/...
 
 script:
-- go vet ./...
-- go test -v ./...
-- gfmxr -c $(grep -c 'package main' README.md) -s README.md
+- ./runtests

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,6 @@ before_script:
 - go get github.com/meatballhat/gfmxr/...
 
 script:
-- ./runtests
+- ./runtests vet
+- ./runtests test
+- ./runtests gfmxr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `context.GlobalBoolT` was added as an analogue to `context.GlobalBool`
 - Support for hiding commands by setting `Hidden: true` -- this will hide the
   commands in help output
+- `./runtests` test runner with coverage tracking by default
 
 ### Changed
 - `Float64Flag`, `IntFlag`, and `DurationFlag` default values are no longer

--- a/runtests
+++ b/runtests
@@ -13,31 +13,49 @@ PACKAGE_NAME = os.environ.get(
 )
 
 
-def main():
-    _run('go vet ./...'.split())
+def main(sysargs=sys.argv[:]):
+    target = 'test'
+    if len(sysargs) > 1:
+        target = sysargs[1]
 
-    if check_output('go version'.split()).split()[2] >= 'go1.2':
-        coverprofiles = []
-        for subpackage in ['', 'altsrc']:
-            coverprofile = 'cli.coverprofile'
-            if subpackage != '':
-                coverprofile = '{}.coverprofile'.format(subpackage)
+    {
+        'vet': _vet,
+        'test': _test,
+        'gfmxr': _gfmxr
+    }[target]()
 
-            coverprofiles.append(coverprofile)
-
-            _run('go test -v'.split() + [
-                '-coverprofile={}'.format(coverprofile),
-                '{}/{}'.format(PACKAGE_NAME, subpackage)
-            ])
-
-        combined = _combine_coverprofiles(coverprofiles)
-        _run('go tool cover -func={}'.format(combined.name).split())
-        combined.close()
-    else:
-        _run('go test -v ./...'.split())
-
-    _run(['gfmxr', '-c', str(_gfmxr_count()), '-s', 'README.md'])
     return 0
+
+
+def _test():
+    if check_output('go version'.split()).split()[2] < 'go1.2':
+        _run('go test -v ./...'.split())
+        return
+
+    coverprofiles = []
+    for subpackage in ['', 'altsrc']:
+        coverprofile = 'cli.coverprofile'
+        if subpackage != '':
+            coverprofile = '{}.coverprofile'.format(subpackage)
+
+        coverprofiles.append(coverprofile)
+
+        _run('go test -v'.split() + [
+            '-coverprofile={}'.format(coverprofile),
+            '{}/{}'.format(PACKAGE_NAME, subpackage)
+        ])
+
+    combined = _combine_coverprofiles(coverprofiles)
+    _run('go tool cover -func={}'.format(combined.name).split())
+    combined.close()
+
+
+def _gfmxr():
+    _run(['gfmxr', '-c', str(_gfmxr_count()), '-s', 'README.md'])
+
+
+def _vet():
+    _run('go vet ./...'.split())
 
 
 def _run(command):

--- a/runtests
+++ b/runtests
@@ -42,7 +42,7 @@ def _test():
 
         _run('go test -v'.split() + [
             '-coverprofile={}'.format(coverprofile),
-            '{}/{}'.format(PACKAGE_NAME, subpackage)
+            ('{}/{}'.format(PACKAGE_NAME, subpackage)).rstrip('/')
         ])
 
     combined = _combine_coverprofiles(coverprofiles)

--- a/runtests
+++ b/runtests
@@ -5,7 +5,7 @@ import os
 import sys
 import tempfile
 
-from subprocess import check_call
+from subprocess import check_call, check_output
 
 
 PACKAGE_NAME = os.environ.get(
@@ -16,22 +16,25 @@ PACKAGE_NAME = os.environ.get(
 def main():
     _run('go vet ./...'.split())
 
-    coverprofiles = []
-    for subpackage in ['', 'altsrc']:
-        coverprofile = 'cli.coverprofile'
-        if subpackage != '':
-            coverprofile = '{}.coverprofile'.format(subpackage)
+    if check_output('go version'.split()).split()[2] >= 'go1.2':
+        coverprofiles = []
+        for subpackage in ['', 'altsrc']:
+            coverprofile = 'cli.coverprofile'
+            if subpackage != '':
+                coverprofile = '{}.coverprofile'.format(subpackage)
 
-        coverprofiles.append(coverprofile)
+            coverprofiles.append(coverprofile)
 
-        _run('go test -v'.split() + [
-            '-coverprofile={}'.format(coverprofile),
-            '{}/{}'.format(PACKAGE_NAME, subpackage)
-        ])
+            _run('go test -v'.split() + [
+                '-coverprofile={}'.format(coverprofile),
+                '{}/{}'.format(PACKAGE_NAME, subpackage)
+            ])
 
-    combined = _combine_coverprofiles(coverprofiles)
-    _run('go tool cover -func={}'.format(combined.name).split())
-    combined.close()
+        combined = _combine_coverprofiles(coverprofiles)
+        _run('go tool cover -func={}'.format(combined.name).split())
+        combined.close()
+    else:
+        _run('go test -v ./...'.split())
 
     _run(['gfmxr', '-c', str(_gfmxr_count()), '-s', 'README.md'])
     return 0

--- a/runtests
+++ b/runtests
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import os
+import sys
+import tempfile
+
+from subprocess import check_call
+
+
+PACKAGE_NAME = os.environ.get(
+    'CLI_PACKAGE_NAME', 'github.com/codegangsta/cli'
+)
+
+
+def main():
+    _run('go vet ./...'.split())
+
+    coverprofiles = []
+    for subpackage in ['', 'altsrc']:
+        coverprofile = 'cli.coverprofile'
+        if subpackage != '':
+            coverprofile = '{}.coverprofile'.format(subpackage)
+
+        coverprofiles.append(coverprofile)
+
+        _run('go test -v'.split() + [
+            '-coverprofile={}'.format(coverprofile),
+            '{}/{}'.format(PACKAGE_NAME, subpackage)
+        ])
+
+    combined = _combine_coverprofiles(coverprofiles)
+    _run('go tool cover -func={}'.format(combined.name).split())
+    combined.close()
+
+    _run(['gfmxr', '-c', str(_gfmxr_count()), '-s', 'README.md'])
+    return 0
+
+
+def _run(command):
+    print('runtests: {}'.format(' '.join(command)), file=sys.stderr)
+    check_call(command)
+
+
+def _gfmxr_count():
+    with open('README.md') as infile:
+        lines = infile.read().splitlines()
+        return len(filter(_is_go_runnable, lines))
+
+
+def _is_go_runnable(line):
+    return line.startswith('package main')
+
+
+def _combine_coverprofiles(coverprofiles):
+    combined = tempfile.NamedTemporaryFile(suffix='.coverprofile')
+    combined.write('mode: set\n')
+
+    for coverprofile in coverprofiles:
+        with open(coverprofile, 'r') as infile:
+            for line in infile.readlines():
+                if not line.startswith('mode: '):
+                    combined.write(line)
+
+    combined.flush()
+    return combined
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
The script is written in Python in the hope that it is available "everywhere", and is slightly more available to Windows folks than bash, although it's been years since I developed primarily on Windows, so I'm happy to port it to something else.