### PR TITLE
Trim go1.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 sudo: false
 
 go:
-- 1.1.2
 - 1.2.2
 - 1.3.3
 - 1.4
@@ -14,6 +13,9 @@ go:
 matrix:
   allow_failures:
   - go: master
+  include:
+  - go: 1.1.2
+    install: go get -v .
 
 before_script:
 - go get github.com/meatballhat/gfmxr/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
   include:
   - go: 1.1.2
     install: go get -v .
+    before_script: echo skipping gfmxr on $TRAVIS_GO_VERSION
+    script:
+    - ./runtests vet
+    - ./runtests test
 
 before_script:
 - go get github.com/meatballhat/gfmxr/...

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Command line apps are usually so tiny that there is absolutely no reason why you
 
 ## Installation
 
-Make sure you have a working Go environment (go 1.1+ is *required*). [See the install instructions](http://golang.org/doc/install.html).
+Make sure you have a working Go environment.  Go version 1.1+ is required for
+core cli, whereas use of the [`./altsrc`](./altsrc) input extensions requires Go
+version 1.2+. [See the install
+instructions](http://golang.org/doc/install.html).
 
 To install cli, simply run:
 ```

--- a/runtests
+++ b/runtests
@@ -33,7 +33,7 @@ def main(sysargs=sys.argv[:]):
 
 def _test():
     if check_output('go version'.split()).split()[2] < 'go1.2':
-        _run('go test -v ./...'.split())
+        _run('go test -v .'.split())
         return
 
     coverprofiles = []


### PR DESCRIPTION
as the upstream yaml dependency in `./altsrc` depends on features present in go1.2+.